### PR TITLE
fix(bambu): start_print returns success on ack timeout with preparing hint

### DIFF
--- a/kiln/src/kiln/printers/bambu.py
+++ b/kiln/src/kiln/printers/bambu.py
@@ -1614,7 +1614,7 @@ class BambuAdapter(PrinterAdapter):
 
     def _wait_for_print_start(
         self,
-        timeout: float = 5.0,
+        timeout: float = 15.0,
         poll_interval: float = 1.0,
     ) -> tuple[str, int | None]:
         """Poll MQTT cache until printer enters a print-active state.
@@ -2213,7 +2213,7 @@ class BambuAdapter(PrinterAdapter):
         # Wait for MQTT confirmation unless already active.
         if not already_active:
             result_state, error_code = self._wait_for_print_start()
-            if result_state in ("timeout", "failed"):
+            if result_state == "failed":
                 # Build a specific error message if we recognise the code.
                 err_detail = ""
                 if error_code is not None:
@@ -2231,9 +2231,24 @@ class BambuAdapter(PrinterAdapter):
                 return PrintResult(
                     success=False,
                     message=(
-                        f"Print command sent for {basename} but printer did not "
-                        f"transition to an active state within timeout."
-                        f"{err_detail}"
+                        f"Print command sent for {basename} but printer "
+                        f"reported a failure.{err_detail}"
+                    ),
+                )
+            if result_state == "timeout":
+                # The printer hasn't transitioned to an active state yet,
+                # but the command was sent successfully.  Bambu printers
+                # can take 5-8+ minutes for their startup sequence
+                # (homing, AMS load, calibration) before gcode_state
+                # flips to "running" or "prepare".  This is normal.
+                with self._state_lock:
+                    current_state = str(self._last_status.get("gcode_state", "unknown")).lower()
+                return PrintResult(
+                    success=True,
+                    message=(
+                        f"Print command accepted for {basename}. Printer is "
+                        f"preparing (state: {current_state}). Use printer_status() "
+                        f"to monitor — print has not yet confirmed running.{warn_suffix}"
                     ),
                 )
             if result_state == "running":

--- a/kiln/tests/test_bambu_adapter.py
+++ b/kiln/tests/test_bambu_adapter.py
@@ -1472,14 +1472,25 @@ class TestBambuAdapterPrintConfirmation:
             result = adapter_with_mqtt.start_print("test.3mf")
         assert result.success is True
 
-    def test_timeout_returns_failure(self, adapter_with_mqtt: BambuAdapter) -> None:
+    def test_timeout_returns_success_with_preparing(self, adapter_with_mqtt: BambuAdapter) -> None:
+        """Cold-start Bambu transitions can exceed the MQTT ack window.
+
+        Historically this returned a scary ``success=False, "did not transition"``
+        even though the print command had been accepted and the printer was
+        simply still in its preheat / calibration phase.  The honest behaviour
+        is to return success with a clear ``preparing`` hint and tell the
+        caller to poll ``printer_status`` to confirm.
+        """
         adapter_with_mqtt._last_status = {"gcode_state": "idle"}
         # Mock time.monotonic to simulate timeout.
         with mock.patch("kiln.printers.bambu.time.monotonic", side_effect=[0.0, 0.0, 100.0]), \
                 mock.patch("kiln.printers.bambu.time.sleep"):
             result = adapter_with_mqtt.start_print("test.3mf")
-        assert result.success is False
-        assert "did not transition" in result.message
+        assert result.success is True
+        assert "accepted" in result.message
+        assert "preparing" in result.message
+        assert "printer_status" in result.message
+        assert "did not transition" not in result.message
 
     def test_skips_wait_when_already_active(self, adapter_with_mqtt: BambuAdapter) -> None:
         adapter_with_mqtt._last_status = {"gcode_state": "running"}
@@ -2603,13 +2614,21 @@ class TestStartPrintErrorMessages:
         assert "12345678" in result.message
         assert "hex" in result.message.lower()
 
-    def test_no_error_code_generic_message(self, adapter_with_mqtt: BambuAdapter) -> None:
+    def test_no_error_code_returns_preparing_success(self, adapter_with_mqtt: BambuAdapter) -> None:
+        """No error code + ack timeout = printer is simply still preparing.
+
+        The honest response is ``success=True`` with a ``preparing`` hint.
+        Previously this returned a scary ``did not transition`` failure
+        even though the command had been accepted.
+        """
         adapter_with_mqtt._last_status = {"gcode_state": "idle", "print_error": 0}
         with mock.patch("kiln.printers.bambu.time.monotonic", side_effect=[0.0, 0.0, 100.0]), \
                 mock.patch("kiln.printers.bambu.time.sleep"):
             result = adapter_with_mqtt.start_print("test.3mf")
-        assert result.success is False
-        assert "did not transition" in result.message
+        assert result.success is True
+        assert "accepted" in result.message
+        assert "preparing" in result.message
+        assert "did not transition" not in result.message
 
 
 class TestValidate3mfFilamentIds:


### PR DESCRIPTION
## Summary
- Bambu's cold-start transition (homing, AMS/external-spool probe, flow cali, vibration cali, bed leveling) can take 5-8+ minutes before `gcode_state` flips to `running`/`prepare`
- Previously the 5s ack window expired during legitimate preheat/calibration and returned `success=False, "did not transition to an active state within timeout"` — a **false failure**
- Now: timeout → `success=True` with `"Print command accepted. Printer is preparing (state: X). Use printer_status() to monitor — print has not yet confirmed running."` — honest and actionable
- Actual failures (`gcode_state == "failed"`) still return `success=False` with a specific "reported a failure" message
- Ack window extended 5s → 15s for margin on slow transitions

## Test plan
- [x] 278 tests in `kiln/tests/test_bambu_adapter.py` pass
- [x] Two existing tests (`test_timeout_returns_failure`, `test_no_error_code_generic_message`) updated to assert the new honest behavior — renamed to reflect intent
- [x] Discovered during the 2026-04-15 coaster print — MCP client reported "timeout" but `printer_status` showed `state=printing` and file live; the print had actually started fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)