### PR TITLE
fix(ci): clear the lint break + stub failures that have kept CI red since 2026-06-04

### DIFF
--- a/kiln/src/kiln/server.py
+++ b/kiln/src/kiln/server.py
@@ -883,10 +883,8 @@ def _record_local_tool_call(name: str) -> None:
     if pro_features is not None:
         # kiln-pro owns recording on this machine; do NOT also run the
         # public ledger below or the same call would be counted twice.
-        try:
+        with contextlib.suppress(Exception):
             pro_features.record_local_tool_call(name)
-        except Exception:
-            pass
         return
     try:
         from kiln import usage_ledger

--- a/kiln/tests/test_base.py
+++ b/kiln/tests/test_base.py
@@ -346,7 +346,7 @@ class TestPrinterAdapterABC:
             def upload_file(self, file_path):
                 return UploadResult(success=True, file_name="", message="")
 
-            def start_print(self, file_name):
+            def _start_print_impl(self, file_name):
                 return PrintResult(success=True, message="")
 
             def cancel_print(self):

--- a/kiln/tests/test_device_generalization.py
+++ b/kiln/tests/test_device_generalization.py
@@ -40,7 +40,7 @@ class TestDeviceAdapterAlias:
             def get_job(self): return JobProgress()
             def list_files(self): return []
             def upload_file(self, p): return UploadResult(success=True, file_name="f", message="ok")
-            def start_print(self, f): return PrintResult(success=True, message="ok")
+            def _start_print_impl(self, f): return PrintResult(success=True, message="ok")
             def cancel_print(self): return PrintResult(success=True, message="ok")
             def pause_print(self): return PrintResult(success=True, message="ok")
             def resume_print(self): return PrintResult(success=True, message="ok")
@@ -125,7 +125,7 @@ class TestOptionalDeviceMethods:
             def get_job(self): return JobProgress()
             def list_files(self): return []
             def upload_file(self, p): return UploadResult(success=True, file_name="f", message="ok")
-            def start_print(self, f): return PrintResult(success=True, message="ok")
+            def _start_print_impl(self, f): return PrintResult(success=True, message="ok")
             def cancel_print(self): return PrintResult(success=True, message="ok")
             def pause_print(self): return PrintResult(success=True, message="ok")
             def resume_print(self): return PrintResult(success=True, message="ok")

--- a/kiln/tests/test_filament_sensor.py
+++ b/kiln/tests/test_filament_sensor.py
@@ -89,7 +89,7 @@ class TestBaseFilamentStatus:
             def upload_file(self, file_path):
                 pass
 
-            def start_print(self, file_name):
+            def _start_print_impl(self, file_name):
                 pass
 
             def cancel_print(self):

--- a/kiln/tests/test_new_features.py
+++ b/kiln/tests/test_new_features.py
@@ -453,7 +453,7 @@ class TestAdapterSnapshot:
             def get_job(self): pass
             def list_files(self): pass
             def upload_file(self, path): pass
-            def start_print(self, name): pass
+            def _start_print_impl(self, name): pass
             def cancel_print(self): pass
             def pause_print(self): pass
             def resume_print(self): pass

--- a/kiln/tests/test_safety_hardening.py
+++ b/kiln/tests/test_safety_hardening.py
@@ -153,7 +153,7 @@ class TestAdapterSafetyProfile:
                 return []
             def upload_file(self, path):
                 pass
-            def start_print(self, name):
+            def _start_print_impl(self, name):
                 pass
             def cancel_print(self):
                 pass


### PR DESCRIPTION
## What broke

CI has failed on every push to main since 2026-06-04 (first red run: 26985798968). Two stacked causes, found by diffing the last green run (26979297120, `d95e922e`) against the first failure:

1. **Lint (the original break):** the usage-ledger wiring merged in `4ca29f08` added a `try/except Exception: pass` in `server.py` that ruff flags as **SIM105**. Every run since has died at the **Lint kiln** step.
2. **Tests (hidden behind the lint break):** the universal pre-print gate (`1fccc98`, June 8) made `PrinterAdapter.start_print` a concrete template method delegating to a new abstract `_start_print_impl` and renamed all 7 real adapters — but the adapter stubs in the test suite still defined `start_print`, so 8 tests across 5 files failed with `TypeError: Can't instantiate abstract class`. They were never seen in CI because lint failed first.

**Note on the kiln-pro guard:** the "Verify kiln-pro is NOT installed in public CI" step was *not* failing — it prints ✓ in every red run (the `import kiln_pro` lines visible in logs are the step's script echo, not output). The guard is untouched by this PR.

## The fix

- `server.py`: `try/except/pass` → `contextlib.suppress(Exception)` (the file's existing idiom; behavior unchanged).
- 5 test files: rename the 6 stub `start_print` definitions to `_start_print_impl`, mirroring the adapter renames. No test called `start_print` on a stub instance.

## Verification

Reproduced CI exactly in a clean venv (locked requirements, `--no-deps` editable installs, kiln-pro absent — `import kiln_pro` fails, matching the guard):

- `ruff check src/` clean in both packages
- kiln: 9794 passed / 396 skipped — the only failure is `test_tessellation_invariance`, which is macOS/arm64-local (it passed on all 4 ubuntu jobs in the last green run with identical code; tracked separately)
- octoprint-cli: 239 passed (matches the green-run baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)