### PR TITLE
docs(readme): note zero-install uvx/npx launch variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Restart your AI app and it can run your printer. (Claude Code and Codex can even
 }
 ```
 
+**No install needed?** Swap the command for a zero-install runner — `"command": "uvx"`, `"args": ["kiln3d", "serve"]` (Python), or `"command": "npx"`, `"args": ["kiln3d"]` (Node). Same server, nothing to `pip install`.
+
 Drop this into Claude Desktop, Claude Code, Codex, Cursor, or any MCP-capable agent. Runs on the free tier until you sign in.
 </details>
 


### PR DESCRIPTION
Adds one sentence to the Manual MCP config block pointing out the zero-install launch commands (`uvx kiln3d serve`, `npx kiln3d`), now that both are live on PyPI 1.2.0 and npm 1.2.0.

Docs-only, +2 lines. Hero and Quick Start intentionally unchanged — uvx/npx are launch commands, not install alternatives, so they belong where MCP client config is documented.