### PR TITLE
feat(npm): add kiln3d npm launcher source

### DIFF
--- a/npm-launcher/README.md
+++ b/npm-launcher/README.md
@@ -1,0 +1,40 @@
+# kiln3d (npm launcher)
+
+**Kiln is the open-source MCP server for 3D printing** — it lets AI agents
+(Claude, Codex, or any MCP client) design, slice, print, monitor, and recover
+real 3D prints on Bambu Lab, Creality, Prusa, Elegoo, Klipper/Moonraker,
+OctoPrint, and more.
+
+This npm package is a thin **launcher**. The actual server is the Python
+package [`kiln3d`](https://pypi.org/project/kiln3d/); this just runs it for you
+via [`uv`](https://docs.astral.sh/uv/) (or `pipx`), so it works from a Node/npx
+setup:
+
+```bash
+npx kiln3d
+```
+
+That launches the Kiln MCP server (`serve`). Any arguments are passed straight
+through, e.g. `npx kiln3d --help`.
+
+## Requirements
+
+Kiln is a Python program, so you need one of:
+
+- **uv** (recommended): `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- **pipx**: `pipx` on your PATH
+
+If neither is present, the launcher prints install instructions and exits.
+
+## Why a launcher instead of a rewrite
+
+The launcher always runs the **latest** published `kiln3d` from PyPI, so new
+Kiln releases reach `npx kiln3d` users automatically — this npm package rarely
+needs a new version.
+
+## Prefer a native install?
+
+- Python: `uvx kiln3d` (zero-install run) or `pip install kiln3d`
+- Full guide: <https://kiln3d.com/install>
+
+License: AGPL-3.0. Source: <https://github.com/codeofaxel/Kiln>

--- a/npm-launcher/bin/kiln3d.js
+++ b/npm-launcher/bin/kiln3d.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+"use strict";
+
+/*
+ * npx kiln3d — thin launcher for Kiln, the open-source MCP server for 3D printing.
+ *
+ * The real program is the Python package `kiln3d` on PyPI. This launcher just
+ * finds a Python runner (uv/uvx first, then pipx) and hands off, passing
+ * through every argument. Because it always runs the LATEST published
+ * `kiln3d`, this npm package does not need re-publishing when Kiln ships a new
+ * version — a `pip`/`uvx` release reaches npx users automatically.
+ *
+ * With no arguments it defaults to `serve` (start the MCP server), so a bare
+ * `npx kiln3d` in an MCP client config just works.
+ */
+
+const { spawnSync } = require("node:child_process");
+
+const passthrough = process.argv.slice(2);
+const args = passthrough.length ? passthrough : ["serve"];
+
+function exists(bin) {
+  const probe = process.platform === "win32" ? "where" : "which";
+  return spawnSync(probe, [bin], { stdio: "ignore" }).status === 0;
+}
+
+function handOff(bin, binArgs) {
+  const result = spawnSync(bin, binArgs, { stdio: "inherit" });
+  process.exit(result.status == null ? 1 : result.status);
+}
+
+if (exists("uvx")) {
+  handOff("uvx", ["kiln3d", ...args]);
+} else if (exists("pipx")) {
+  handOff("pipx", ["run", "kiln3d", ...args]);
+} else {
+  process.stderr.write(
+    [
+      "",
+      "Kiln runs on Python and needs `uv` (recommended) or `pipx` to launch.",
+      "",
+      "  Install uv (macOS/Linux):  curl -LsSf https://astral.sh/uv/install.sh | sh",
+      '  Install uv (Windows):      powershell -c "irm https://astral.sh/uv/install.ps1 | iex"',
+      "",
+      "Then re-run:                 npx kiln3d",
+      "",
+      "Full install guide: https://kiln3d.com/install",
+      "",
+    ].join("\n")
+  );
+  process.exit(1);
+}

--- a/npm-launcher/package.json
+++ b/npm-launcher/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "kiln3d",
+  "version": "1.2.0",
+  "description": "Launcher for Kiln — the open-source MCP server for 3D printing. Lets AI agents (Claude, Codex, or any MCP client) design, slice, print, monitor, and recover real 3D prints. Runs the Python package `kiln3d` via uv/pipx.",
+  "bin": {
+    "kiln3d": "bin/kiln3d.js"
+  },
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "model-context-protocol",
+    "3d-printing",
+    "3d-printer",
+    "ai-agent",
+    "ai",
+    "bambu",
+    "octoprint",
+    "klipper",
+    "moonraker",
+    "prusa",
+    "creality",
+    "elegoo",
+    "slicer"
+  ],
+  "homepage": "https://kiln3d.com",
+  "bugs": "https://github.com/codeofaxel/Kiln/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codeofaxel/Kiln.git",
+    "directory": "npm-launcher"
+  },
+  "license": "AGPL-3.0",
+  "author": "Kiln Contributors",
+  "files": [
+    "bin/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
Version-controls the source of the `kiln3d` npm package (published to npm as 1.2.0).

`npx kiln3d` launches the Python MCP server via uv/pipx, passing args through and defaulting to `serve`. It always runs the latest PyPI release, so it needs no re-publish per Kiln version. Replaces the empty 1.0.0 placeholder that was on npm.

Packaging-only: new `npm-launcher/` directory, no changes to existing code.