### PR TITLE
docs(server): explain intentional SHA-256 in _key_fingerprint

### DIFF
--- a/kiln/src/kiln/server.py
+++ b/kiln/src/kiln/server.py
@@ -479,6 +479,13 @@ def _key_fingerprint(key: str) -> str:
         return "(empty)"
     import hashlib
 
+    # SHA-256 (not a slow KDF like bcrypt/argon2) is intentional and safe
+    # here: this is a log-correlation fingerprint, not password storage.
+    # The digest is never persisted and never used to authenticate — it
+    # only masks a key in logs and lets us compare whether env and YAML
+    # resolved to the same key.  A salted slow hash would be
+    # non-deterministic and break that comparison, for no security gain.
+    # (Same rationale as auth.py:_hash_key.)
     return "sha256:" + hashlib.sha256(key.encode()).hexdigest()[:8]
 
 


### PR DESCRIPTION
Adds a rationale comment to `_key_fingerprint` explaining that SHA-256 is intentional and safe here: it produces a **non-reversible log-correlation fingerprint** (key masking + env-vs-YAML comparison), not password storage. The digest is never persisted and never authenticates.

A salted slow KDF (bcrypt/argon2) would be non-deterministic and break the equality comparison the fingerprint exists for, for zero security benefit on high-entropy machine tokens. This mirrors the already-documented rationale in `auth.py:_hash_key` and pre-empts a future "weak hash" refactor.

Comment-only — no behavior change. Compiles clean; ruff passes.

Context: resolves the (now-dismissed) CodeQL `py/weak-sensitive-data-hashing` alert #21, which flagged this line as password hashing.