### PR TITLE
fix(lint): combine design_intelligence imports in design_tools.py

### DIFF
--- a/kiln/src/kiln/plugins/design_tools.py
+++ b/kiln/src/kiln/plugins/design_tools.py
@@ -655,8 +655,7 @@ class _DesignToolsPlugin:
             Args:
                 template: Template identifier.
             """
-            from kiln.design_intelligence import get_public_design_template
-            from kiln.design_intelligence import list_public_design_templates
+            from kiln.design_intelligence import get_public_design_template, list_public_design_templates
 
             try:
                 record = get_public_design_template(template)


### PR DESCRIPTION
Ruff `I001` flagged the two consecutive `from kiln.design_intelligence import …` lines in `plugins/design_tools.py` as an un-sorted import block. Because the Lint step runs across the whole package, this **single violation has been failing CI on `main` and on every open PR** (the last 5 `main` runs are all red for this reason alone).

Combines them into one import statement — 2 lines to 1, ruff's own autofix.

**No behavior change.**

Verified:
- `ruff check src/kiln/` — all checks passed (no new `E501`)
- `py_compile` — OK
- module import smoke — OK
- `pytest --collect-only` — 10,742 tests collected, no import breakage