### PR TITLE
fix(tests): skip SBOM lock currency tests on Python 3.10

### DIFF
--- a/kiln/tests/test_sbom_lock_currency.py
+++ b/kiln/tests/test_sbom_lock_currency.py
@@ -24,10 +24,15 @@ Regeneration command lives in the header of ``requirements-lock.txt``.
 from __future__ import annotations
 
 import re
-import tomllib
 from pathlib import Path
 
 import pytest
+
+# ``tomllib`` is stdlib only on Python 3.11+, but kiln supports 3.10.
+# These tests compare repo file contents (pyproject vs the lock file),
+# so running them on 3.11+ already gives full coverage — skipping the
+# module on 3.10 loses nothing and avoids a tomli dependency.
+tomllib = pytest.importorskip("tomllib")
 
 _KILN_ROOT = Path(__file__).resolve().parent.parent
 _PYPROJECT = _KILN_ROOT / "pyproject.toml"


### PR DESCRIPTION
`tomllib` entered the stdlib in **Python 3.11**, but `pyproject.toml` declares `requires-python = ">=3.10"` and the CI matrix includes **3.10**.

The bare module-level `import tomllib` raised `ModuleNotFoundError` during collection, which **aborted the entire kiln test suite** on the 3.10 job:

```
ERROR collecting tests/test_sbom_lock_currency.py
E   ModuleNotFoundError: No module named 'tomllib'
!!!! Interrupted: 1 error during collection !!!!
```

Uses `pytest.importorskip("tomllib")` so 3.10 skips the module cleanly instead of failing collection. No `tomli` dependency is added: these tests compare **repo file contents** (`pyproject.toml` vs `requirements-lock.txt`), so the 3.11/3.12/3.13 jobs already give full coverage.

Verified:
- 8 passed on 3.11+
- `importorskip` confirmed to raise `Skipped` (not a collection error) when tomllib is absent
- `ruff check` — all checks passed

Note: this was the *second* of two stacked pre-existing failures on `main`; the ruff `I001` error in #106 was masking it by failing the Lint step first.