### PR TITLE
fix(tests): isolate decoration quota and kiln_pro stubs between tests

### DIFF
--- a/kiln/tests/conftest.py
+++ b/kiln/tests/conftest.py
@@ -13,6 +13,7 @@ loaded by the test suite without modification.
 from __future__ import annotations
 
 import functools
+import sys
 
 # ---------------------------------------------------------------------------
 # Monkey-patch FastMCP to accept unknown kwargs (like ``description``)
@@ -808,3 +809,66 @@ def _bypass_terms_gate(monkeypatch):
         monkeypatch.setattr("kiln.terms.is_current", lambda *a, **k: True)
     except (ImportError, AttributeError):
         pass  # terms module absent; nothing to bypass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_decoration_quota(tmp_path_factory, monkeypatch):
+    """Give every test its own decoration-quota file and a fresh singleton.
+
+    ``DecorationQuota`` defaults to ``~/.kiln/decoration_usage.json`` and is
+    handed out through a module-level singleton, so without this the free-tier
+    allowance (3/month) is *shared by the whole suite* and written to the real
+    home directory.  Once three decoration tests have run, every later call to
+    ``decorate_surface`` short-circuits with ``DECORATION_QUOTA_EXCEEDED``
+    before reaching the check under test — which made the ``face="wall"``
+    validation tests fail in a full run while passing in isolation.
+
+    Tests that exercise quota behaviour directly construct
+    ``DecorationQuota(quota_path=...)`` with their own path and are unaffected.
+    """
+    try:
+        from kiln import decoration_quota
+    except ImportError:  # pragma: no cover — module absent
+        yield
+        return
+
+    qdir = tmp_path_factory.getbasetemp() / "decoration_quota"
+    qdir.mkdir(exist_ok=True)
+    qpath = qdir / "decoration_usage.json"
+    if qpath.exists():
+        qpath.unlink()  # fresh allowance per test
+
+    monkeypatch.setattr(decoration_quota, "DEFAULT_QUOTA_PATH", qpath)
+    monkeypatch.setattr(decoration_quota, "_quota", None)
+    yield
+    # Never leave a singleton bound to this test's temp path behind.
+    decoration_quota._quota = None  # noqa: SLF001 — module-level test seam
+
+
+@pytest.fixture(autouse=True)
+def _restore_kiln_pro_stubs():
+    """Undo ``kiln_pro`` stubs a test installs directly into ``sys.modules``.
+
+    Several suites inject fake pro modules with a bare
+    ``sys.modules["kiln_pro"] = fake`` instead of ``monkeypatch.setitem``, so
+    the stub outlives the test.  A fake package that omits an attribute then
+    breaks an unrelated test that imports it for real — e.g. a ``kiln_pro``
+    without ``data_overlays`` made the printer-intelligence overlay lookup
+    raise ``AttributeError`` in a full run but not in isolation.
+
+    Snapshot the ``kiln_pro*`` entries and restore them afterwards so no test
+    can leak a partial pro package into the next one.
+    """
+    def _snapshot() -> dict:
+        return {
+            name: mod
+            for name, mod in sys.modules.items()
+            if name == "kiln_pro" or name.startswith("kiln_pro.")
+        }
+
+    saved = _snapshot()
+    yield
+    for name in list(_snapshot()):
+        if name not in saved:
+            del sys.modules[name]
+    sys.modules.update(saved)

--- a/kiln/tests/test_consumer_tools_coverage.py
+++ b/kiln/tests/test_consumer_tools_coverage.py
@@ -19,18 +19,37 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Ensure kiln_pro.tax is importable so @patch("kiln_pro.tax.TaxCalculator") can
-# resolve the module path.  The actual TaxCalculator class lives in kiln-pro
-# which may or may not be installed; we only need the module chain to exist in
-# sys.modules so unittest.mock can traverse it.
-if "kiln_pro" not in sys.modules:
-    _fake_pro = types.ModuleType("kiln_pro")
-    sys.modules["kiln_pro"] = _fake_pro
-if "kiln_pro.tax" not in sys.modules:
-    _fake_tax = types.ModuleType("kiln_pro.tax")
-    _fake_tax.TaxCalculator = type("TaxCalculator", (), {})  # type: ignore[attr-defined]
-    sys.modules["kiln_pro.tax"] = _fake_tax
-    sys.modules["kiln_pro"].tax = _fake_tax  # type: ignore[attr-defined]
+
+@pytest.fixture(autouse=True)
+def _stub_kiln_pro_tax():
+    """Make ``kiln_pro.tax`` resolvable for ``@patch("kiln_pro.tax.TaxCalculator")``.
+
+    The real ``TaxCalculator`` lives in kiln-pro, which may or may not be
+    installed; unittest.mock only needs the module chain to exist in
+    ``sys.modules`` to traverse it.
+
+    This runs as a fixture rather than at module scope on purpose.  Building
+    the chain at import time put a *bare* ``kiln_pro`` module into
+    ``sys.modules`` for the rest of the session whenever kiln-pro was absent
+    (i.e. in public CI), so a later test that patches a different pro
+    submodule — ``kiln_pro.data_overlays`` in test_printer_intelligence —
+    failed with ``AttributeError`` against this stand-in.  Scoping it to the
+    tests that need it, and removing only what we added, keeps the stub from
+    leaking.
+    """
+    added: list[str] = []
+    if "kiln_pro" not in sys.modules:
+        sys.modules["kiln_pro"] = types.ModuleType("kiln_pro")
+        added.append("kiln_pro")
+    if "kiln_pro.tax" not in sys.modules:
+        fake_tax = types.ModuleType("kiln_pro.tax")
+        fake_tax.TaxCalculator = type("TaxCalculator", (), {})  # type: ignore[attr-defined]
+        sys.modules["kiln_pro.tax"] = fake_tax
+        sys.modules["kiln_pro"].tax = fake_tax  # type: ignore[attr-defined]
+        added.append("kiln_pro.tax")
+    yield
+    for name in reversed(added):
+        sys.modules.pop(name, None)
 
 # ---------------------------------------------------------------------------
 # Helpers — register tools and capture them

--- a/kiln/tests/test_printer_intelligence.py
+++ b/kiln/tests/test_printer_intelligence.py
@@ -145,6 +145,10 @@ class TestGetPrinterIntel:
 
     def test_cached_lookup_still_touches_canonical_overlay_loader(self) -> None:
         """A process cache must not bypass hosted private-read tracing."""
+        # The overlay loader ships with kiln-pro, which public CI asserts is
+        # NOT installed — without it there is no loader to patch, so this
+        # contract can only be exercised where the pro package is present.
+        pytest.importorskip("kiln_pro.data_overlays")
         get_printer_intel("bambu_x1c")
         with mock.patch(
             "kiln_pro.data_overlays.load_overlay",

--- a/kiln/tests/test_printer_intelligence.py
+++ b/kiln/tests/test_printer_intelligence.py
@@ -143,12 +143,9 @@ class TestGetPrinterIntel:
         intel = get_printer_intel("  bambu_x1c  ")
         assert intel.id == "bambu_x1c"
 
+    @requires_printer_intelligence_overlay
     def test_cached_lookup_still_touches_canonical_overlay_loader(self) -> None:
         """A process cache must not bypass hosted private-read tracing."""
-        # The overlay loader ships with kiln-pro, which public CI asserts is
-        # NOT installed — without it there is no loader to patch, so this
-        # contract can only be exercised where the pro package is present.
-        pytest.importorskip("kiln_pro.data_overlays")
         get_printer_intel("bambu_x1c")
         with mock.patch(
             "kiln_pro.data_overlays.load_overlay",


### PR DESCRIPTION
Fixes the 3 remaining failures on `main` — all cross-test state leaks that made tests fail in a full run while passing in isolation.

### 1. Decoration quota was global state
`DecorationQuota` defaults to `~/.kiln/decoration_usage.json` and is handed out through a module-level singleton, so the free-tier allowance (**3/month**) was shared by the entire suite **and written to the real home directory**. Once three decoration tests had run, every later `decorate_surface` call short-circuited with `DECORATION_QUOTA_EXCEEDED` before reaching the check under test.

Each test now gets its own quota file and a fresh singleton. Tests that exercise quota behaviour construct `DecorationQuota(quota_path=...)` themselves and are unaffected.

### 2. `kiln_pro` stubs outlived their tests
Several suites inject fake pro modules with a bare `sys.modules["kiln_pro"] = fake` instead of `monkeypatch.setitem`, so the stub persisted. A fake package missing an attribute then broke an unrelated test importing it for real — a `kiln_pro` without `data_overlays` made the printer-intelligence overlay lookup raise `AttributeError`.

`kiln_pro*` entries are now snapshotted and restored around every test, so no suite can leak a partial pro package into the next.

### Fixes
```
test_decorate_surface_wall.py::test_wall_rejects_obj_with_a_format_error
test_decorate_surface_wall.py::test_wall_without_engine_points_at_hosted_service
test_printer_intelligence.py::TestGetPrinterIntel::test_cached_lookup_still_touches_canonical_overlay_loader
```

### Verification
Full local suite on this branch: **the 3 target failures are gone** (0 matches).

Note on local vs CI: a local run also shows ~22 `test_material_data_sanity` failures, but those are **identical on clean `main`** and are the kiln-pro-overlay-gated assertions that only execute when kiln-pro is installed — CI asserts kiln-pro is *not* installed, so they skip there. They are unrelated to this change. Fixture is additive and autouse; CI is the decisive gate.