### PR TITLE
Load tool: answer for every material, and stop advertising a stale list

### DIFF
--- a/kiln/scripts/generate_load_tables.py
+++ b/kiln/scripts/generate_load_tables.py
@@ -92,13 +92,34 @@ SIGMA_T_MPA = {
     "pvb": 40.0,
 }
 
-# The three elastomer grades are EXCLUDED on physics, not on effort.  This
-# table derives a safe load from tensile capacity at a cantilever root, which
-# assumes the part fails in bending rather than deflecting.  An elastomer does
-# the opposite: it bends out of the way long before it breaks, so a "safe load"
-# derived this way would describe a failure mode TPU does not have.  A load
-# question about TPU is a deflection question and needs a different model.
-_EXCLUDED_ELASTOMERS = ("tpu", "tpu_85a", "tpu_95a")
+# The three elastomer grades are answered by a DIFFERENT MODEL, not left blank.
+# The strength table above derives a safe load from tensile capacity at a
+# cantilever root, which assumes the part fails in bending.  An elastomer does
+# the opposite: it bends out of the way long before it breaks (TPU stretches
+# 450-600% before rupture), so a strength-derived "safe load" would describe a
+# failure mode TPU does not have.
+#
+# The honest question for an elastomer is serviceability: at what load does it
+# deflect so far it stops doing its job?  That is standard cantilever
+# deflection, d = F L^3 / (3 E I), solved for the load at an allowable
+# deflection.  Using a square section (I = A^2/12, matching the strength
+# table's basis) and an allowable deflection of L/10:
+#
+#     F = 3 E I d / L^3  ->  F = E * A^2 / (40 * L^2)
+#
+# These are SERVICEABILITY loads, not strength loads, and they are published
+# under their own key with their own units so the two can never be confused.
+_ELASTOMERS = ("tpu", "tpu_85a", "tpu_95a")
+
+# Young's modulus, MPa (= N/mm^2). Mirrors kiln-pro's materials overlay, which
+# pins these values so the two cannot drift.
+E_MODULUS_MPA = {
+    "tpu": 80.0,
+    "tpu_85a": 18.0,
+    "tpu_95a": 80.0,
+}
+
+DEFLECTION_LIMIT_RATIO = 10.0   # allowable deflection = L / 10
 
 SAFETY_FACTOR = 3.0
 FDM_PRINT_FACTOR = 0.9          # printed vs datasheet-bar strength
@@ -119,6 +140,23 @@ def tensile_capacity(material: str) -> float:
 def safe_load_n(material: str, area_mm2: float, length_mm: float) -> float:
     z_mm3 = area_mm2 ** 1.5 / 6.0
     return _floor2(tensile_capacity(material) * z_mm3 / length_mm)
+
+
+def _floor4(x: float) -> float:
+    """Round DOWN to 4 decimals. Deflection loads on a soft elastomer at a long
+    span are fractions of a gram; two decimals collapses distinct geometries to
+    a meaningless 0.0, and rounding must never add capacity."""
+    return math.floor(x * 10000.0) / 10000.0
+
+
+def deflection_limited_load_n(material: str, area_mm2: float, length_mm: float) -> float:
+    """Load at which a square elastomer cantilever deflects L/10.
+
+    Serviceability, not strength: an elastomer reaches an unusable deflection
+    long before it ruptures, so this is the number that actually governs.
+    """
+    e_mpa = E_MODULUS_MPA[material]
+    return _floor4(e_mpa * (area_mm2 ** 2) / (40.0 * (length_mm ** 2)))
 
 
 def build() -> dict:
@@ -171,6 +209,40 @@ def build() -> dict:
                 "across_layers": ACROSS_LAYER_DERATE,
                 "along_layers": 1.0,
             },
+        }
+
+    # Elastomers, answered by the serviceability model. Deliberately a
+    # DIFFERENT key with DIFFERENT field names: these are deflection-limited
+    # loads, and nothing should be able to read them as strength values.
+    for material in _ELASTOMERS:
+        doc[material] = {
+            "limit_mode": "deflection",
+            "youngs_modulus_mpa": E_MODULUS_MPA[material],
+            "deflection_limit_ratio": DEFLECTION_LIMIT_RATIO,
+            "cross_section_vs_deflection_load": [
+                {
+                    "cantilever_length_mm": length,
+                    "allowable_deflection_mm": round(length / DEFLECTION_LIMIT_RATIO, 2),
+                    "entries": [
+                        {
+                            "cross_section_mm2": area,
+                            "load_at_deflection_limit_n": deflection_limited_load_n(
+                                material, area, length
+                            ),
+                        }
+                        for area in CROSS_SECTIONS_MM2
+                    ],
+                }
+                for length in CANTILEVER_LENGTHS_MM
+            ],
+            "notes": [
+                "This material does not fail in bending at these loads — it "
+                "deflects. The figures are the load at which the part bends "
+                "L/10, which is what stops it doing its job.",
+                "For a part that must hold its shape under load, choose a "
+                "rigid material; sizing an elastomer for stiffness means "
+                "changing geometry, not expecting more from the polymer.",
+            ],
         }
     return doc
 

--- a/kiln/src/kiln/data/design_knowledge/load_tables.json
+++ b/kiln/src/kiln/data/design_knowledge/load_tables.json
@@ -4695,5 +4695,428 @@
       "across_layers": 0.4,
       "along_layers": 1.0
     }
+  },
+  "tpu": {
+    "limit_mode": "deflection",
+    "youngs_modulus_mpa": 80.0,
+    "deflection_limit_ratio": 10.0,
+    "cross_section_vs_deflection_load": [
+      {
+        "cantilever_length_mm": 25,
+        "allowable_deflection_mm": 2.5,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.4608
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 1.8432
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 4.1472
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 7.3728
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 11.52
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 50,
+        "allowable_deflection_mm": 5.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.4608
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 1.0368
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 1.8432
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 2.88
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 100,
+        "allowable_deflection_mm": 10.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0288
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.2592
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.4608
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.72
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 150,
+        "allowable_deflection_mm": 15.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0128
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.0512
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.2048
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.32
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 200,
+        "allowable_deflection_mm": 20.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0072
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.0288
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.0648
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.18
+          }
+        ]
+      }
+    ],
+    "notes": [
+      "This material does not fail in bending at these loads \u2014 it deflects. The figures are the load at which the part bends L/10, which is what stops it doing its job.",
+      "For a part that must hold its shape under load, choose a rigid material; sizing an elastomer for stiffness means changing geometry, not expecting more from the polymer."
+    ]
+  },
+  "tpu_85a": {
+    "limit_mode": "deflection",
+    "youngs_modulus_mpa": 18.0,
+    "deflection_limit_ratio": 10.0,
+    "cross_section_vs_deflection_load": [
+      {
+        "cantilever_length_mm": 25,
+        "allowable_deflection_mm": 2.5,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.1036
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.4147
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.9331
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 1.6588
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 2.592
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 50,
+        "allowable_deflection_mm": 5.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0259
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.1036
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.2332
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.4147
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.648
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 100,
+        "allowable_deflection_mm": 10.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0064
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.0259
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.0583
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.1036
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.162
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 150,
+        "allowable_deflection_mm": 15.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0028
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.0115
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.0259
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.046
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.072
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 200,
+        "allowable_deflection_mm": 20.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0016
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.0064
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.0145
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.0259
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.0405
+          }
+        ]
+      }
+    ],
+    "notes": [
+      "This material does not fail in bending at these loads \u2014 it deflects. The figures are the load at which the part bends L/10, which is what stops it doing its job.",
+      "For a part that must hold its shape under load, choose a rigid material; sizing an elastomer for stiffness means changing geometry, not expecting more from the polymer."
+    ]
+  },
+  "tpu_95a": {
+    "limit_mode": "deflection",
+    "youngs_modulus_mpa": 80.0,
+    "deflection_limit_ratio": 10.0,
+    "cross_section_vs_deflection_load": [
+      {
+        "cantilever_length_mm": 25,
+        "allowable_deflection_mm": 2.5,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.4608
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 1.8432
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 4.1472
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 7.3728
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 11.52
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 50,
+        "allowable_deflection_mm": 5.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.4608
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 1.0368
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 1.8432
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 2.88
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 100,
+        "allowable_deflection_mm": 10.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0288
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.2592
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.4608
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.72
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 150,
+        "allowable_deflection_mm": 15.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0128
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.0512
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.2048
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.32
+          }
+        ]
+      },
+      {
+        "cantilever_length_mm": 200,
+        "allowable_deflection_mm": 20.0,
+        "entries": [
+          {
+            "cross_section_mm2": 12,
+            "load_at_deflection_limit_n": 0.0072
+          },
+          {
+            "cross_section_mm2": 24,
+            "load_at_deflection_limit_n": 0.0288
+          },
+          {
+            "cross_section_mm2": 36,
+            "load_at_deflection_limit_n": 0.0648
+          },
+          {
+            "cross_section_mm2": 48,
+            "load_at_deflection_limit_n": 0.1152
+          },
+          {
+            "cross_section_mm2": 60,
+            "load_at_deflection_limit_n": 0.18
+          }
+        ]
+      }
+    ],
+    "notes": [
+      "This material does not fail in bending at these loads \u2014 it deflects. The figures are the load at which the part bends L/10, which is what stops it doing its job.",
+      "For a part that must hold its shape under load, choose a rigid material; sizing an elastomer for stiffness means changing geometry, not expecting more from the polymer."
+    ]
   }
 }

--- a/kiln/src/kiln/design_intelligence.py
+++ b/kiln/src/kiln/design_intelligence.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import math
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -2069,6 +2070,53 @@ def _check_filament_printer_compat(
 # ---------------------------------------------------------------------------
 # Public API — Structural and environmental reasoning
 # ---------------------------------------------------------------------------
+
+
+def load_table_materials() -> list[str]:
+    """Every material the load lookup can answer for, strength or deflection.
+
+    Derived from the table so it can never drift from reality — a hardcoded
+    list here told users only five materials were available long after the
+    table carried thirty-five.
+    """
+    return sorted(k for k in _get_kb().load_tables if not k.startswith("_"))
+
+
+def estimate_deflection_limited_load(
+    material_id: str,
+    cross_section_mm2: float,
+    cantilever_length_mm: float,
+) -> dict[str, Any] | None:
+    """Serviceability answer for an elastomer, or ``None`` if not one.
+
+    An elastomer does not fail in bending at these loads — it deflects out of
+    the way. This returns the load at which the section bends L/10, which is
+    the limit that actually governs, clearly labelled so it can never be read
+    as a strength value.
+    """
+    rec = _get_kb().load_tables.get((material_id or "").lower())
+    if not isinstance(rec, dict) or rec.get("limit_mode") != "deflection":
+        return None
+    rows = sorted(
+        rec.get("cross_section_vs_deflection_load", []),
+        key=lambda r: float(r.get("cantilever_length_mm", 0.0)),
+    )
+    if not rows or cross_section_mm2 <= 0 or cantilever_length_mm <= 0:
+        return None
+    e_mpa = float(rec.get("youngs_modulus_mpa", 0.0))
+    ratio = float(rec.get("deflection_limit_ratio", 10.0))
+    if e_mpa <= 0:
+        return None
+    # Same closed form the generator uses: F = E * A^2 / (4 * ratio * L^2)
+    load = e_mpa * (cross_section_mm2 ** 2) / (4.0 * ratio * (cantilever_length_mm ** 2))
+    return {
+        "material": (material_id or "").lower(),
+        "limit_mode": "deflection",
+        "load_at_deflection_limit_n": math.floor(load * 10000.0) / 10000.0,
+        "allowable_deflection_mm": round(cantilever_length_mm / ratio, 2),
+        "youngs_modulus_mpa": e_mpa,
+        "reasoning": list(rec.get("notes", [])),
+    }
 
 
 def estimate_load_capacity(

--- a/kiln/src/kiln/plugins/design_tools.py
+++ b/kiln/src/kiln/plugins/design_tools.py
@@ -542,10 +542,35 @@ class _DesignToolsPlugin:
                     load_across_layers=load_across_layers,
                 )
                 if estimate is None:
+                    # An elastomer is not "unknown" — it is governed by a
+                    # different limit. It deflects out of the way long before
+                    # it breaks, so answer the question that actually applies
+                    # instead of returning nothing.
+                    from kiln.design_intelligence import (
+                        estimate_deflection_limited_load,
+                        load_table_materials,
+                    )
+
+                    flex = estimate_deflection_limited_load(
+                        material, cross_section_mm2, cantilever_length_mm
+                    )
+                    if flex is not None:
+                        flex["success"] = True
+                        flex["safety_basis"] = (
+                            "This is a SERVICEABILITY limit, not a strength "
+                            "limit: the load at which the section bends "
+                            f"{flex['allowable_deflection_mm']} mm (L/10). "
+                            "The part will not break here — it will simply "
+                            "bend too far to do its job. If it must hold its "
+                            "shape under load, use a rigid material; an "
+                            "elastomer is made stiffer by changing geometry, "
+                            "not by expecting more of the polymer."
+                        )
+                        return flex
                     return {
                         "success": False,
                         "error": f"Unknown load table material: {material}. "
-                        "Available: pla, petg, abs, nylon, polycarbonate.",
+                        f"Available: {', '.join(load_table_materials())}.",
                     }
                 result = estimate.to_dict()
                 result["success"] = True

--- a/kiln/tests/test_intelligence_parity.py
+++ b/kiln/tests/test_intelligence_parity.py
@@ -57,13 +57,9 @@ KNOWN_GAPS: dict[str, set[str]] = {
     # rating there would be noise dressed as coverage.
     "co_print_compatibility": {"pps"},
     "post_processing": set(),
-    # Closed 2026-07-25 by extending the generator from five materials to
-    # every RIGID one. The three that remain are a deliberate physics
-    # exclusion, not debt: this table derives a safe load from tensile
-    # capacity at a cantilever root, which assumes the part fails in bending.
-    # An elastomer deflects out of the way instead, so the figure would
-    # describe a failure mode TPU does not have.
-    "load_tables": {"tpu", "tpu_85a", "tpu_95a"},
+    # Closed entirely: the 35 rigid materials by the bending model, the 3
+    # elastomers by the deflection model. Every material is answerable.
+    "load_tables": set(),
 }
 
 # Table keys that are legitimately NOT catalog materials.  skin_contact

--- a/kiln/tests/test_load_tables_derivation.py
+++ b/kiln/tests/test_load_tables_derivation.py
@@ -49,6 +49,8 @@ def test_every_load_rederives_from_the_bending_formula():
     for material, entry in doc.items():
         if material.startswith("_"):
             continue
+        if entry.get("limit_mode") == "deflection":
+            continue  # a different model — re-derived in its own test below
         cap = entry["tensile_capacity_n_per_mm2"]
         # The capacity field itself re-derives from the declared basis.
         expected_cap = round(
@@ -71,6 +73,8 @@ def test_orientation_pair_is_weak_below_strong_everywhere():
     for material, entry in _table().items():
         if material.startswith("_"):
             continue
+        if entry.get("limit_mode") == "deflection":
+            continue  # deflection is a stiffness limit; no strength derate applies
         od = entry["layer_orientation_derating"]
         assert od["across_layers"] < od["along_layers"], material
         assert 0.0 < od["across_layers"] <= 0.6, material
@@ -81,13 +85,41 @@ def test_table_monotonic_in_area_and_length():
     for material, entry in _table().items():
         if material.startswith("_"):
             continue
-        rows = sorted(entry["cross_section_vs_load"],
-                      key=lambda r: r["cantilever_length_mm"])
+        deflection = entry.get("limit_mode") == "deflection"
+        key = "cross_section_vs_deflection_load" if deflection else "cross_section_vs_load"
+        load_key = "load_at_deflection_limit_n" if deflection else "max_load_n"
+        rows = sorted(entry[key], key=lambda r: r["cantilever_length_mm"])
         for row in rows:
-            loads = [c["max_load_n"] for c in row["entries"]]
+            loads = [c[load_key] for c in row["entries"]]
             assert loads == sorted(loads) and len(set(loads)) == len(loads), (
                 material, row["cantilever_length_mm"])
         for r1, r2 in zip(rows, rows[1:]):
             for c1, c2 in zip(r1["entries"], r2["entries"]):
-                assert c2["max_load_n"] < c1["max_load_n"], (
+                assert c2[load_key] < c1[load_key], (
                     material, r1["cantilever_length_mm"], r2["cantilever_length_mm"])
+
+
+def test_every_deflection_load_rederives_from_the_stiffness_formula():
+    """The elastomer entries re-derive too — a different model, equally pinned.
+
+    F = E * A^2 / (4 * ratio * L^2), the cantilever deflection equation
+    d = F L^3 / (3 E I) solved for the load at an allowable deflection, with
+    a square section (I = A^2/12) to match the strength table's basis.
+    """
+    gen = _load_generator()
+    for material, entry in _table().items():
+        if material.startswith("_") or entry.get("limit_mode") != "deflection":
+            continue
+        e_mpa = entry["youngs_modulus_mpa"]
+        assert e_mpa == gen.E_MODULUS_MPA[material], material
+        ratio = entry["deflection_limit_ratio"]
+        for row in entry["cross_section_vs_deflection_load"]:
+            length = row["cantilever_length_mm"]
+            assert row["allowable_deflection_mm"] == round(length / ratio, 2), material
+            for cell in row["entries"]:
+                area = cell["cross_section_mm2"]
+                exact = e_mpa * (area ** 2) / (4.0 * ratio * (length ** 2))
+                stored = cell["load_at_deflection_limit_n"]
+                # floor-rounded: never above the formula, never a full step below
+                assert stored <= exact + 1e-9, (material, length, area)
+                assert stored >= exact - 0.0001, (material, length, area)

--- a/kiln/tests/test_no_silent_material_gaps.py
+++ b/kiln/tests/test_no_silent_material_gaps.py
@@ -1,0 +1,156 @@
+"""No catalogue material may be met with silence, on any intelligence surface.
+
+This is the universal version of a bug this repo has now shipped three times,
+in three different tables, each time the same shape:
+
+  * skin contact went quiet for 13 of the 25 materials in v1.2.0 — a worn part
+    in TPU 95A, wood-fill or matte PLA got no warning at all;
+  * the load lookup answered for five materials and returned ``None`` for the
+    other thirty, while telling the user only five existed;
+  * co-print answered ``abs`` about ``tpu`` and stayed silent when asked the
+    same question from the other side.
+
+In every case nothing failed, no test went red, and no error was raised. The
+lookup simply returned nothing, and an assistant reading nothing reports "no
+data available" — which a user hears as "no concern here". For a safety
+surface that is the worst possible failure: silence is indistinguishable from
+an all-clear, and it is reached by doing nothing at all.
+
+So this file asserts the one property that makes the whole class impossible:
+EVERY material in the catalogue gets a real answer from EVERY per-material
+intelligence surface. An answer may be a value, or it may be an explicit,
+reasoned refusal ("this model does not describe an elastomer", "nobody has
+characterised this material") — both are answers. Returning ``None`` or ``{}``
+is not.
+
+Coverage of the DATA is tracked separately, per table, in
+test_intelligence_parity.py. This file is about the ANSWER: a material may
+legitimately be absent from a table, but the surface built on that table must
+still say something true when asked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kiln import design_intelligence as di
+
+DATA = Path(__file__).parent.parent / "src" / "kiln" / "data" / "design_knowledge"
+
+# A representative geometry — small enough to be realistic, large enough that
+# no surface can dodge the question by treating it as degenerate.
+_AREA_MM2 = 24.0
+_LENGTH_MM = 50.0
+
+
+def _materials() -> list[str]:
+    raw = json.loads((DATA / "materials.json").read_text(encoding="utf-8"))
+    return sorted(k for k in raw if not k.startswith("_"))
+
+
+MATERIALS = _materials()
+
+
+def test_the_catalogue_is_not_empty():
+    """Guard the guard: an empty roster would make every test below vacuous."""
+    assert len(MATERIALS) >= 38, (
+        f"only {len(MATERIALS)} materials found — if the catalogue really "
+        "shrank, update this floor deliberately; otherwise the loader is broken "
+        "and every per-material test in this file is silently passing on nothing"
+    )
+
+
+@pytest.mark.parametrize("material", MATERIALS)
+def test_skin_contact_always_answers(material: str):
+    """A part worn against skin never gets silence — see the three-tier floor."""
+    floor = di.get_skin_contact_floor(material)
+    assert floor is not None, (
+        f"{material}: no skin-contact answer at all. Silence reads as 'no "
+        "concern' on a safety question; the floor must fall back to a related "
+        "family or to the generic uncharacterised record."
+    )
+    assert floor.honesty_note, f"{material}: skin floor returned but says nothing"
+    assert floor.refer_to_medical, f"{material}: skin floor lost its medical boundary"
+
+
+@pytest.mark.parametrize("material", MATERIALS)
+def test_load_question_always_answers(material: str):
+    """Strength OR deflection — every material gets one of the two.
+
+    An elastomer is not 'unknown': it is governed by deflection rather than
+    rupture. Returning nothing for it told users the material was unsupported
+    when the honest answer was that they were asking the wrong question.
+    """
+    strength = di.estimate_load_capacity(material, _AREA_MM2, _LENGTH_MM)
+    if strength is not None:
+        assert strength.max_load_n >= 0.0
+        return
+    flex = di.estimate_deflection_limited_load(material, _AREA_MM2, _LENGTH_MM)
+    assert flex is not None, (
+        f"{material}: neither a strength nor a deflection answer. Every "
+        "material must be answerable by one model or the other, and the "
+        "answer must name which."
+    )
+    assert flex["limit_mode"] == "deflection"
+    assert flex["load_at_deflection_limit_n"] >= 0.0
+    assert flex["reasoning"], f"{material}: deflection answer with no explanation"
+
+
+def test_load_tool_never_advertises_a_stale_material_list():
+    """The available-materials list is derived, never hardcoded.
+
+    A hardcoded list told users only five materials were supported long after
+    the table carried thirty-five — the feature looked a seventh of its real
+    size, and nothing failed.
+    """
+    advertised = set(di.load_table_materials())
+    actual = {
+        k for k in json.loads((DATA / "load_tables.json").read_text(encoding="utf-8"))
+        if not k.startswith("_")
+    }
+    assert advertised == actual, (
+        "the advertised load-table materials have drifted from the table "
+        f"itself: only-advertised={sorted(advertised - actual)}, "
+        f"only-in-table={sorted(actual - advertised)}"
+    )
+    assert advertised >= set(MATERIALS), (
+        "every catalogue material must be answerable by the load lookup: "
+        f"missing {sorted(set(MATERIALS) - advertised)}"
+    )
+
+
+@pytest.mark.parametrize("material", MATERIALS)
+def test_environment_question_always_answers(material: str):
+    """Durability in the real world — sun, heat, damp, chemicals, wear."""
+    report = di.check_environment_compatibility(material, "outdoor use in direct sun")
+    assert report is not None, (
+        f"{material}: no environment answer. A material with no durability "
+        "record must still say so rather than return nothing."
+    )
+
+
+@pytest.mark.parametrize("material", MATERIALS)
+def test_co_print_question_always_answers(material: str):
+    """Asked against a common partner, every material says something.
+
+    Interface adhesion is a property of a boundary, so this must also hold
+    from either side — a pair that answered one way round and stayed silent
+    the other shipped in this repo.
+    """
+    for partner in ("pla", "petg"):
+        if partner == material:
+            continue
+        forward = di.check_multi_material_compatibility(material, partner)
+        reverse = di.check_multi_material_compatibility(partner, material)
+        assert forward is not None, f"{material}+{partner}: no answer"
+        assert reverse is not None, f"{partner}+{material}: no answer (reverse)"
+        assert forward.interface_adhesion, (
+            f"{material}+{partner}: answered with an empty adhesion verdict"
+        )
+        assert forward.interface_adhesion == reverse.interface_adhesion, (
+            f"{material}+{partner}: answers differ by direction — "
+            f"{forward.interface_adhesion} vs {reverse.interface_adhesion}"
+        )


### PR DESCRIPTION
Two live defects on `estimate_structural_load`, both the silent-gap shape this catalogue keeps hitting.

**The advertised list was stale.** The tool hardcoded `"Available: pla, petg, abs, nylon, polycarbonate"` — true when the table held 5 materials, wrong now it holds 38. A user asking about PEEK was told the feature was a seventh of its real size. Now derived from the table, with a test pinning the two together.

**The elastomers now answer instead of returning "unknown."** TPU isn't unknown — it's governed by a different limit. The strength table assumes failure in bending; TPU stretches 450–600% and deflects out of the way long before it breaks. So the three grades are solved by the model that applies: cantilever deflection `d = F·L³/(3EI)` solved for the load at `L/10`, published under their own key/field names so a serviceability load can never be read as a strength load. 4-decimal resolution there — a soft grade at long span carries fractions of a gram, and 2 decimals collapsed distinct geometries to `0.0` (caught by the monotonicity test).

**New guard — `test_no_silent_material_gaps.py`.** Every catalogue material must get a real answer from every per-material surface (skin contact, load, durability, co-print). An explicit reasoned refusal counts; returning `None`/`{}` does not. **Verified to fail on a seeded regression**, not just to pass.

## Verify
468 passed across the affected surface. Branch cut from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)