### PR TITLE
changelog: high-temp adhesives + material intelligence coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- **How to glue the high-temperature plastics (Pro+).** Adhesive intelligence
+  now covers PPS and Ultem (PEI 1010 and 9085) — surface prep and which
+  adhesive actually holds.
+
 - **Bambu X1E and H2S reach their full nozzle temperature.** Kiln now
   respects each printer's real limit, so high-temp filaments print
   without a false "too hot" error.
@@ -73,6 +77,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   those numbers sharpen faster.*
 
 ### Changed
+
+- **Material intelligence now answers for every filament Kiln knows.** Skin
+  contact, durability, multi-material bonding and safe-load guidance used to
+  go quiet on less common materials — including everyday ones like TPU 95A,
+  wood-fill and matte PLA. They answer across the catalogue now.
 
 - **Iterating is free — a design is only spent when you keep it.** Try as many
   looks as you like; your free monthly designs are spent only when you download,


### PR DESCRIPTION
Two user-facing lines for 1.2.1.

**Added** — adhesive intelligence for PPS and Ultem (PEI 1010/9085). Genuinely new.

**Changed** — material intelligence now answers for every filament. Skin contact, durability, multi-material bonding and safe-load all shipped earlier and went quiet on less common materials (TPU 95A, wood-fill, matte PLA); they answer across the catalogue now. Deliberately filed under Changed, not Added — these are not new features.

Not listed: the load tool's stale material list and its refusal on flexible filaments. Both real, both fixed in #110, neither worth a line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)