### PR TITLE
fix(watchdog): exempt heater warmup from the temperature and stall rules

### DIFF
--- a/kiln/src/kiln/print_watchdog.py
+++ b/kiln/src/kiln/print_watchdog.py
@@ -22,9 +22,10 @@ Red flags (any triggers e-stop):
 
 * ``state.print_error`` non-zero
 * ``state.hms_code`` (or equivalent) matches a blocklist entry
-* Tool temperature drops > 30°C below setpoint during active print
-* Bed temperature drops > 15°C below setpoint during active print
-* No layer progress for > 90 seconds while state == PRINTING
+* Tool temperature drops > 30°C below setpoint, after it first reaches it
+* Bed temperature drops > 15°C below setpoint, after it first reaches it
+* A heater stops climbing while still below its setpoint
+* No layer progress for > 90 seconds while printing and not heating
 * Printer reports any configured HMS blocklist code
 
 Yellow flags (logged, no e-stop):
@@ -69,6 +70,19 @@ WIFI_WARN_DBM: int = -80
 #: Minimum target temperature considered "actually heating" — below this
 #: the heater is off or cooling, and drops below setpoint are expected.
 MIN_ACTIVE_TARGET_C: float = 30.0
+
+#: How close to setpoint a heater must come to count as having reached it.
+#: Comfortably wider than steady-state PID wobble.
+REACHED_MARGIN_C: float = 5.0
+
+#: Temperature rise that counts as a heater still climbing.  Wider than
+#: sensor noise and than the resolution printers report in.
+HEATING_RISE_C: float = 1.0
+
+#: How long a heater may show no such rise, while further below setpoint
+#: than the drop threshold, before the gap counts as a fault.  A heater
+#: climbing slowly is fine at any speed; one that has stopped is not.
+DEFAULT_NO_RISE_TIMEOUT_S: float = 120.0
 
 
 # --------------------------------------------------------------------------
@@ -117,6 +131,8 @@ class PrintWatchdog:
         tool_drop_c: Override for tool-temp drop threshold.
         bed_drop_c: Override for bed-temp drop threshold.
         stall_seconds: Override for layer-stall timeout.
+        no_rise_timeout_s: Override for how long a warming heater may
+            show no temperature rise before the gap counts as a failure.
         time_fn: Injectable clock for deterministic testing.  Defaults
             to :func:`time.monotonic`.
     """
@@ -131,6 +147,7 @@ class PrintWatchdog:
         tool_drop_c: float = DEFAULT_TOOL_DROP_C,
         bed_drop_c: float = DEFAULT_BED_DROP_C,
         stall_seconds: float = DEFAULT_STALL_SECONDS,
+        no_rise_timeout_s: float = DEFAULT_NO_RISE_TIMEOUT_S,
         time_fn: Callable[[], float] = time.monotonic,
     ) -> None:
         self._adapter = adapter
@@ -140,6 +157,7 @@ class PrintWatchdog:
         self._tool_drop_c = float(tool_drop_c)
         self._bed_drop_c = float(bed_drop_c)
         self._stall_seconds = float(stall_seconds)
+        self._no_rise_timeout_s = float(no_rise_timeout_s)
         self._time = time_fn
 
         # Threading primitives.
@@ -155,6 +173,14 @@ class PrintWatchdog:
         self._last_state: Any = None
         self._last_job: Any = None
         self._flags: list[Flag] = []
+
+        # Warmup tracking: a drop only counts once its heater has arrived.
+        self._tool_reached = False
+        self._tool_target_prev: float | None = None
+        self._tool_rise_ref: tuple[float, float] | None = None
+        self._bed_reached = False
+        self._bed_target_prev: float | None = None
+        self._bed_rise_ref: tuple[float, float] | None = None
 
     # ------------------------------------------------------------------
     # Public lifecycle
@@ -314,18 +340,34 @@ class PrintWatchdog:
             self._last_completion = None
             self._last_layer = None
             self._last_progress_time = now
+            # Clear warmup tracking so the next print checks afresh.
+            self._tool_reached = False
+            self._tool_target_prev = None
+            self._tool_rise_ref = None
+            self._bed_reached = False
+            self._bed_target_prev = None
+            self._bed_rise_ref = None
             return None
 
         # --- Tool temperature drop -----------------------------------
         tool_actual = _getattr(state, "tool_temp_actual")
         tool_target = _getattr(state, "tool_temp_target")
+        tool_warming = False
         if (
             tool_actual is not None
             and tool_target is not None
             and tool_target >= MIN_ACTIVE_TARGET_C
         ):
+            if self._tool_target_prev != tool_target:
+                # New setpoint: the heater has to climb to it again.
+                self._tool_target_prev = tool_target
+                self._tool_reached = False
+            if tool_actual >= tool_target - REACHED_MARGIN_C:
+                self._tool_reached = True
+                self._tool_rise_ref = None
+            tool_warming = not self._tool_reached
             drop = tool_target - tool_actual
-            if drop >= self._tool_drop_c:
+            if drop >= self._tool_drop_c and self._tool_reached:
                 return Flag(
                     kind="red",
                     rule="tool_drop",
@@ -341,17 +383,53 @@ class PrintWatchdog:
                         "drop_c": float(drop),
                     },
                 )
+            if tool_warming:
+                if self._tool_rise_ref is None:
+                    self._tool_rise_ref = (tool_actual, now)
+                ref_c, ref_at = self._tool_rise_ref
+                if tool_actual >= ref_c + HEATING_RISE_C:
+                    self._tool_rise_ref = (tool_actual, now)
+                elif now - ref_at >= self._no_rise_timeout_s:
+                    return Flag(
+                        kind="red",
+                        rule="tool_not_heating",
+                        message=(
+                            f"Hotend stopped climbing {drop:.1f}°C below setpoint "
+                            f"({tool_actual:.1f}°C vs {tool_target:.0f}°C target) "
+                            f"— heater failure or thermistor fault"
+                        ),
+                        timestamp=now,
+                        context={
+                            "tool_temp_actual": float(tool_actual),
+                            "tool_temp_target": float(tool_target),
+                            "no_rise_seconds": float(now - ref_at),
+                        },
+                    )
+        elif tool_target is not None and tool_target < MIN_ACTIVE_TARGET_C:
+            # Heater switched off, as filament-change macros do with M104 S0.
+            # The rise reference stays: a target toggling through zero must not
+            # restart the timer, or a dead heater is never reported.
+            self._tool_reached = False
+            self._tool_target_prev = None
 
         # --- Bed temperature drop ------------------------------------
         bed_actual = _getattr(state, "bed_temp_actual")
         bed_target = _getattr(state, "bed_temp_target")
+        bed_warming = False
         if (
             bed_actual is not None
             and bed_target is not None
             and bed_target >= MIN_ACTIVE_TARGET_C
         ):
+            if self._bed_target_prev != bed_target:
+                self._bed_target_prev = bed_target
+                self._bed_reached = False
+            if bed_actual >= bed_target - REACHED_MARGIN_C:
+                self._bed_reached = True
+                self._bed_rise_ref = None
+            bed_warming = not self._bed_reached
             drop = bed_target - bed_actual
-            if drop >= self._bed_drop_c:
+            if drop >= self._bed_drop_c and self._bed_reached:
                 return Flag(
                     kind="red",
                     rule="bed_drop",
@@ -366,8 +444,36 @@ class PrintWatchdog:
                         "drop_c": float(drop),
                     },
                 )
+            if bed_warming:
+                if self._bed_rise_ref is None:
+                    self._bed_rise_ref = (bed_actual, now)
+                ref_c, ref_at = self._bed_rise_ref
+                if bed_actual >= ref_c + HEATING_RISE_C:
+                    self._bed_rise_ref = (bed_actual, now)
+                elif now - ref_at >= self._no_rise_timeout_s:
+                    return Flag(
+                        kind="red",
+                        rule="bed_not_heating",
+                        message=(
+                            f"Bed stopped climbing {drop:.1f}°C below setpoint "
+                            f"({bed_actual:.1f}°C vs {bed_target:.0f}°C target) "
+                            f"— heater failure or thermistor fault"
+                        ),
+                        timestamp=now,
+                        context={
+                            "bed_temp_actual": float(bed_actual),
+                            "bed_temp_target": float(bed_target),
+                            "no_rise_seconds": float(now - ref_at),
+                        },
+                    )
+        elif bed_target is not None and bed_target < MIN_ACTIVE_TARGET_C:
+            self._bed_reached = False
+            self._bed_target_prev = None
 
         # --- Layer / completion stall --------------------------------
+        if tool_warming or bed_warming:
+            # Heating blocks the G-code stream, so no progress is expected.
+            self._last_progress_time = now
         progressed = self._update_progress(job, now)
         if not progressed and self._last_progress_time is not None:
             stalled = now - self._last_progress_time

--- a/kiln/tests/test_print_watchdog.py
+++ b/kiln/tests/test_print_watchdog.py
@@ -16,8 +16,13 @@ import pytest
 
 from kiln.print_watchdog import (
     DEFAULT_BED_DROP_C,
+    DEFAULT_NO_RISE_TIMEOUT_S,
+    DEFAULT_POLL_INTERVAL,
     DEFAULT_STALL_SECONDS,
     DEFAULT_TOOL_DROP_C,
+    HEATING_RISE_C,
+    MIN_ACTIVE_TARGET_C,
+    REACHED_MARGIN_C,
     Flag,
     PrintWatchdog,
 )
@@ -123,8 +128,12 @@ def _make_watchdog(
 class TestToolTempDrop:
     def test_triggers_when_tool_drops_below_threshold(self):
         wd, adapter, _, anomalies = _make_watchdog()
-        # Drop hotend 35°C below a 220°C target — exceeds default 30°C threshold.
+        # Reach the setpoint first so the drop check is armed — a gap
+        # present before first reach is a warmup ramp, not a drop.
         adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 220.0
+        assert wd.step() is None
+        # Drop hotend 35°C below the target — exceeds default 30°C threshold.
         adapter.state.tool_temp_actual = 220.0 - (DEFAULT_TOOL_DROP_C + 5.0)
 
         flag = wd.step()
@@ -170,7 +179,10 @@ class TestToolTempDrop:
 class TestBedTempDrop:
     def test_triggers_when_bed_drops_below_threshold(self):
         wd, adapter, _, _ = _make_watchdog()
+        # Reach the setpoint first so the drop check is armed.
         adapter.state.bed_temp_target = 60.0
+        adapter.state.bed_temp_actual = 60.0
+        assert wd.step() is None
         adapter.state.bed_temp_actual = 60.0 - (DEFAULT_BED_DROP_C + 2.0)
 
         flag = wd.step()
@@ -228,6 +240,274 @@ class TestPrintError:
 
         assert flag is not None
         assert adapter.emergency_stops == 1
+
+
+
+
+# --------------------------------------------------------------------------
+# Warmup grace
+# --------------------------------------------------------------------------
+
+
+class TestWarmupGrace:
+    """A heater on its way to its target must not be read as a failed one."""
+
+    def test_cold_start_ramp_does_not_trip(self):
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.bed_temp_target = 60.0
+
+        for i in range(72):  # a three minute ramp from ambient
+            frac = i / 71
+            adapter.state.tool_temp_actual = 25.0 + (220.0 - 25.0) * frac
+            adapter.state.bed_temp_actual = 25.0 + (60.0 - 25.0) * frac
+            adapter.job.current_layer += 1
+            assert wd.step() is None
+            clock.advance(DEFAULT_POLL_INTERVAL)
+
+        assert adapter.emergency_stops == 0
+
+    def test_check_starts_once_the_heater_arrives(self):
+        wd, adapter, _, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 25.0
+        assert wd.step() is None  # far below target, but on its way up
+
+        adapter.state.tool_temp_actual = 220.0
+        assert wd.step() is None  # arrived
+        adapter.state.tool_temp_actual = 220.0 - (DEFAULT_TOOL_DROP_C + 5.0)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_drop"
+
+    def test_heater_that_never_heats_is_reported(self):
+        wd, adapter, clock, anomalies = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 25.0
+        assert wd.step() is None
+
+        clock.advance(DEFAULT_NO_RISE_TIMEOUT_S - DEFAULT_POLL_INTERVAL)
+        assert wd.step() is None  # not yet: the deadline has not passed
+        clock.advance(DEFAULT_POLL_INTERVAL * 2)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_not_heating"
+        assert flag.kind == "red"
+        assert flag.context["no_rise_seconds"] >= DEFAULT_NO_RISE_TIMEOUT_S
+        assert adapter.emergency_stops == 1
+        assert anomalies[0].rule == "tool_not_heating"
+
+    def test_bed_that_never_heats_is_reported(self):
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.bed_temp_target = 60.0
+        adapter.state.bed_temp_actual = 20.0
+        assert wd.step() is None
+        clock.advance(DEFAULT_NO_RISE_TIMEOUT_S + 1.0)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "bed_not_heating"
+        assert flag.kind == "red"
+        assert adapter.emergency_stops == 1
+
+    def test_a_slow_climb_is_accepted_at_any_speed(self):
+        """The rule is whether a heater is still climbing, not how fast."""
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 25.0
+        rise_per_poll = HEATING_RISE_C / 4  # far slower than any real heater
+
+        for _ in range(int(DEFAULT_NO_RISE_TIMEOUT_S / DEFAULT_POLL_INTERVAL) * 3):
+            adapter.state.tool_temp_actual += rise_per_poll
+            adapter.job.current_layer += 1
+            assert wd.step() is None
+            clock.advance(DEFAULT_POLL_INTERVAL)
+
+        assert adapter.emergency_stops == 0
+
+    def test_a_heater_that_stops_climbing_is_reported(self):
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 100.0
+        wd.step()
+        clock.advance(DEFAULT_NO_RISE_TIMEOUT_S + 1.0)
+        adapter.job.current_layer += 1
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_not_heating"
+
+    def test_stall_timer_holds_while_warming_then_releases(self):
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 25.0
+        wd.step()
+
+        clock.advance(DEFAULT_STALL_SECONDS + 30.0)
+        adapter.state.tool_temp_actual = 100.0  # still climbing
+        assert wd.step() is None  # no stall while warming
+
+        adapter.state.tool_temp_actual = 220.0  # arrived; the hold ends
+        wd.step()
+        clock.advance(DEFAULT_STALL_SECONDS + 1.0)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "stalled_layer"
+
+    def test_missing_reading_does_not_stop_the_check(self):
+        wd, adapter, _, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 220.0
+        assert wd.step() is None  # arrived
+        adapter.state.tool_temp_actual = None  # one reading goes missing
+        assert wd.step() is None
+        adapter.state.tool_temp_actual = 220.0 - (DEFAULT_TOOL_DROP_C + 5.0)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_drop"
+
+    def test_missing_reading_does_not_restart_the_timer(self):
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 25.0
+        assert wd.step() is None
+        clock.advance(DEFAULT_NO_RISE_TIMEOUT_S - 10.0)
+
+        adapter.state.tool_temp_actual = None  # missing near the deadline
+        adapter.job.current_layer += 1  # keep the stall rule quiet
+        assert wd.step() is None
+
+        clock.advance(20.0)
+        adapter.state.tool_temp_actual = 25.0
+        adapter.job.current_layer += 1
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_not_heating"
+
+    def test_a_setpoint_change_does_not_restart_the_timer(self):
+        """The timer measures time since the last rise, whatever the target."""
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_actual = 200.0  # stuck here for the whole test
+        adapter.state.tool_temp_target = 240.0
+        assert wd.step() is None
+
+        clock.advance(DEFAULT_NO_RISE_TIMEOUT_S / 2)
+        adapter.state.tool_temp_target = 220.0  # target changes, heater does not move
+        adapter.job.current_layer += 1
+        assert wd.step() is None
+
+        clock.advance(DEFAULT_NO_RISE_TIMEOUT_S / 2 + 1.0)
+        adapter.state.tool_temp_target = 240.0
+        adapter.job.current_layer += 1
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_not_heating"
+
+    def test_a_small_steady_shortfall_is_never_reported(self):
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 220.0 - (REACHED_MARGIN_C - 2.0)
+
+        for _ in range(int(DEFAULT_NO_RISE_TIMEOUT_S / DEFAULT_POLL_INTERVAL) + 20):
+            adapter.job.current_layer += 1
+            assert wd.step() is None
+            clock.advance(DEFAULT_POLL_INTERVAL)
+
+        adapter.state.tool_temp_actual = 220.0 - (DEFAULT_TOOL_DROP_C + 5.0)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_drop"
+
+    def test_a_second_print_checks_from_scratch(self):
+        wd, adapter, clock, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 220.0
+        wd.step()
+
+        adapter.state.state = "idle"
+        adapter.state.tool_temp_actual = 25.0
+        wd.step()
+        clock.advance(300.0)
+
+        adapter.state.state = "printing"  # second print, same target, cold again
+        for i in range(72):
+            adapter.state.tool_temp_actual = 25.0 + (220.0 - 25.0) * (i / 71)
+            adapter.job.current_layer += 1
+            assert wd.step() is None
+            clock.advance(DEFAULT_POLL_INTERVAL)
+
+        adapter.state.tool_temp_actual = 220.0 - (DEFAULT_TOOL_DROP_C + 5.0)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_drop"
+
+    def test_raising_the_target_is_treated_as_warming(self):
+        wd, adapter, _, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 200.0
+        adapter.state.tool_temp_actual = 200.0
+        assert wd.step() is None  # arrived at 200
+
+        adapter.state.tool_temp_target = 240.0  # now 40 below the new target
+        assert wd.step() is None
+
+        adapter.state.tool_temp_actual = 240.0
+        assert wd.step() is None  # arrived again
+        adapter.state.tool_temp_actual = 240.0 - (DEFAULT_TOOL_DROP_C + 5.0)
+
+        flag = wd.step()
+
+        assert flag is not None
+        assert flag.rule == "tool_drop"
+
+    def test_switching_a_heater_off_and_on_is_treated_as_warming(self):
+        wd, adapter, _, _ = _make_watchdog()
+        adapter.state.tool_temp_target = 220.0
+        adapter.state.tool_temp_actual = 220.0
+        assert wd.step() is None
+
+        adapter.state.tool_temp_target = MIN_ACTIVE_TARGET_C - 1.0  # M104 S0
+        adapter.state.tool_temp_actual = 150.0
+        assert wd.step() is None
+
+        adapter.state.tool_temp_target = 220.0  # back on, still cool
+        adapter.state.tool_temp_actual = 120.0
+        assert wd.step() is None
+
+        assert adapter.emergency_stops == 0
+
+    def test_switching_the_bed_off_and_on_is_treated_as_warming(self):
+        wd, adapter, _, _ = _make_watchdog()
+        adapter.state.bed_temp_target = 60.0
+        adapter.state.bed_temp_actual = 60.0
+        assert wd.step() is None
+
+        adapter.state.bed_temp_target = MIN_ACTIVE_TARGET_C - 1.0
+        adapter.state.bed_temp_actual = 40.0
+        assert wd.step() is None
+
+        adapter.state.bed_temp_target = 60.0
+        adapter.state.bed_temp_actual = 30.0
+        assert wd.step() is None
+
+        assert adapter.emergency_stops == 0
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The watchdog stops prints that start from a cold printer, about 3 seconds in.

It does this by sending M112, an emergency stop. That halts the printer's firmware. The printer then has to be switched off and on again before it will accept anything.

**This only happens on printers that say they are printing before they have finished heating.** OctoPrint does this. So do other programs that drive Marlin printers.

Here is why. A print file begins with commands that heat the nozzle and the bed. Those commands sit inside the print job and wait there. So the printer reports that it is printing while it is really still warming up. The watchdog checks the temperature during that time. It sees a nozzle at room temperature with a 200C target and reports a failed heater.

Printers that wait until heating is finished before saying they are printing never show that gap. Bambu printers work that way. That is the likely reason this has not been reported before.

Recorded on a Creality Ender-3 V3 SE, three times, the same each time:

```
rule='tool_drop'
message='Hotend dropped 174.1C below setpoint (25.9C vs 200C target) - likely clog or heater failure'
context={'tool_temp_actual': 25.91, 'tool_temp_target': 200.0, 'drop_c': 174.09}
```

A nozzle at room temperature with a 200C target is not a failed heater. It is a print that just started.

## Root cause

Two rules cannot tell a heater that is warming up from one that has failed.

1. **`tool_drop` and `bed_drop`** stop the print when the temperature is far below the target. Neither rule records whether the heater ever reached that target. A heater on its way up therefore looks the same as a heater that died.
2. **`stalled_layer`** stops the print when no layer finishes for 90 seconds. Heating blocks the print file from running, so no layer can finish. A cold start that got past the temperature rules would be stopped by this one instead.

## Fix

1. **The temperature check waits until its heater has reached the target once.** Until then, being below the target counts as warming up.
2. **The 90 second layer timer pauses while a heater is warming**, and runs normally again once it is done.
3. **A heater that stops climbing is reported.** While a heater is warming, the watchdog watches the temperature rise. If it has not risen 1C in 120 seconds, it reports `tool_not_heating` or `bed_not_heating`. A heater climbing slowly is accepted at any speed.
4. **All of this resets between prints, when the target changes, and when a heater is switched off.** A filament change switches the nozzle off and back on, and the reheat must not read as a failure.

## Why watch the rise instead of using a time limit

An earlier version of this fix waited a fixed 20 minutes before calling a heater dead. That number is very hard to choose. A stock bed heating to an ABS temperature can take more than 15 minutes and still be working correctly. Too short a limit stops good prints. Too long a limit means a dead heater goes unreported for a long time.

Watching whether the temperature is rising removes the question:

- A heater that climbs slowly is accepted, at any speed.
- A heater that has stopped climbing is reported in about 2 minutes.

## What does not change

1. Once a heater has reached its target, every rule behaves exactly as before: same thresholds, same rule names, same messages, same context keys.
2. Printers that report printing only after heating are already at temperature on the first check, so nothing about their behavior changes.
3. No pre-flight code is touched.
4. One case is different. A heater that never reaches its target used to be reported as `tool_drop` immediately. It is now reported as `tool_not_heating` once it stops climbing.

## Numbers used

| Name | Value | Meaning |
| --- | --- | --- |
| `REACHED_MARGIN_C` | 5C | How close to the target counts as having reached it |
| `HEATING_RISE_C` | 1C | A rise this size means the heater is still climbing |
| `DEFAULT_NO_RISE_TIMEOUT_S` | 120s | How long with no rise before reporting a fault |

The last one can be changed when the watchdog is created.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Refactor (no functional changes)
- [ ] Tests

## Testing

**On hardware.** A Creality Ender-3 V3 SE through OctoPrint, started cold at 26C, with the watchdog running and able to send a real emergency stop. The nozzle climbed to 215C and the bed to 65C. At 81 seconds the nozzle was still 49C below its target, which is well past the threshold that used to stop the print, and nothing was reported. The print then ran to completion. The same printer produced the emergency stop three times before this change.

**Unit tests** (`kiln/tests/test_print_watchdog.py`). 21 of the 23 existing tests are unchanged and pass. The other 2 began with a heater far below a target it had never reached and expected an immediate stop. That starting state is the same as warming up, so they now bring the heater to temperature first and then drop it. What they assert is unchanged.

15 tests were added:

1. A full cold ramp reports nothing, and the check starts working once the heater arrives.
2. A heater that never heats is reported, for the nozzle and for the bed.
3. The layer timer stays paused while heating, and missing temperature readings neither switch the check off nor restart the timer.
4. A heater held below target is reported even while the target keeps changing, and a small steady shortfall inside the allowed range is never reported.
5. A second print, a target raised mid-print, and a heater switched off and on are each treated as normal warming.

**Full suite.** 11525 passed, 29 failed, 451 skipped. Running the same suite on an unmodified `main` in the same environment also gives 29 failures, with the same list of failing test IDs. Those are image-rendering tests that need rendering software this machine does not have. The number of passing tests differs by exactly the 15 that were added.

**Lint.** `ruff check` reports no problems in either changed file.

## Checklist

- [x] `pytest` passes for affected package(s)
- [x] No `TODO` in critical paths (print jobs, file upload, temperature control, G-code execution, auth)
- [ ] Docs updated if adding CLI commands, MCP tools, or adapters — not applicable, nothing changes in the CLI, MCP or adapter interfaces
- [ ] New adapter implements all `PrinterAdapter` abstract methods (if applicable) — not applicable
- [x] Pre-flight checks not bypassed or weakened
- [x] Temperature and G-code changes validated against safety profiles
