### PR TITLE
feat(slicer): drive the BambuStudio/OrcaSlicer command line

### DIFF
--- a/kiln/src/kiln/slicer.py
+++ b/kiln/src/kiln/slicer.py
@@ -259,6 +259,80 @@ def _get_version(slicer_path: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _split_bambu_profiles(profile: str) -> tuple[list[str], list[str]]:
+    """Route a ``;``-separated profile list to this CLI's two load flags.
+
+    Routing reads the ``type`` inside each file because a filament profile
+    given to ``--load-settings`` is accepted and then ignored.
+    """
+    import json
+
+    settings: list[str] = []
+    filaments: list[str] = []
+    for entry in profile.split(";"):
+        path = os.path.abspath(os.path.expanduser(entry.strip()))
+        if not path:
+            continue
+        if not os.path.isfile(path):
+            raise SlicerError(f"Profile file not found: {os.path.basename(path)}")
+        try:
+            with open(path, encoding="utf-8") as fh:
+                kind = str(json.load(fh)["type"]).lower()
+        except (OSError, UnicodeDecodeError, ValueError, KeyError, TypeError) as exc:
+            # This CLI exits 251 on a PrusaSlicer .ini with an empty stderr, so
+            # name the file here instead.
+            raise SlicerError(
+                f"{os.path.basename(path)} is not a {_CLI_BAMBU} profile. This "
+                f"slicer loads JSON profiles carrying a 'type' field."
+            ) from exc
+        (filaments if kind == "filament" else settings).append(path)
+    return settings, filaments
+
+
+def _build_bambu_command(
+    slicer: SlicerInfo,
+    input_abs: str,
+    work_dir: str,
+    profile: str | None,
+) -> list[str]:
+    """Build a headless slice command for the BambuStudio/OrcaSlicer CLI."""
+    cmd = [slicer.path]
+    if profile:
+        settings, filaments = _split_bambu_profiles(profile)
+        if settings:
+            cmd += ["--load-settings", ";".join(settings)]
+        if filaments:
+            cmd += ["--load-filaments", ";".join(filaments)]
+    # --arrange 0: the caller positions the model, the slicer must not move it.
+    # --slice 1: one plate, since slice_file returns one file.
+    cmd += ["--arrange", "0", "--slice", "1", "--outputdir", work_dir, input_abs]
+    return cmd
+
+
+def _bambu_failure_detail(work_dir: str | None) -> str:
+    """Return the reason this CLI logged for a failed run, if it wrote one."""
+    if work_dir is None:
+        return ""
+    for log in sorted(Path(work_dir).glob("*.log")):
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            text = log.read_text(encoding="utf-8", errors="replace").strip()
+            if text:
+                return text.splitlines()[-1]
+    return ""
+
+
+def _collect_bambu_output(work_dir: str, out_file: str, stdout: str) -> None:
+    """Move this CLI's self-named output (``plate_1.gcode``) to *out_file*."""
+    produced = sorted(
+        p for p in Path(work_dir).iterdir() if p.suffix.lower() in {".gcode", ".gco", ".g"}
+    )
+    if not produced:
+        raise SlicerError(
+            f"The slicer reported success but produced no G-code. stdout: {stdout.strip()[:300]}"
+        )
+    shutil.move(str(produced[0]), out_file)
+
+
 def _gcode_output_is_complete(out_file: str) -> bool:
     """Whether *out_file* looks like a finished slice, not a truncated one.
 
@@ -302,6 +376,9 @@ def slice_file(
         output_name: Override the output file name.  Defaults to the
             input file's stem with ``.gcode`` extension.
         profile: Path to a slicer profile/config file (.ini or .json).
+            The BambuStudio/OrcaSlicer CLI takes a ``;``-separated list
+            instead; each entry is routed by the ``type`` it declares, so
+            order does not matter.  ``~`` is expanded.
         slicer_path: Explicit slicer binary path.  Auto-detected if omitted.
         extra_args: Additional CLI arguments to pass to the slicer.
         timeout: Maximum slicing time in seconds (default 300).
@@ -326,23 +403,10 @@ def slice_file(
     # Find slicer
     slicer = find_slicer(slicer_path)
 
-    # Say what is actually wrong.  Every command below is PrusaSlicer dialect,
-    # so an Orca/BambuStudio binary used to reach the subprocess and come back
-    # with "Invalid option --export-gcode" and exit 254 — a message about a
-    # flag, for a user who chose a slicer.  Refusing here costs nothing that
-    # worked a moment ago: those flags never ran on these binaries.
-    if slicer_cli_family(slicer) == _CLI_BAMBU:
-        raise SlicerError(
-            f"{os.path.basename(slicer.path)} uses the BambuStudio/OrcaSlicer "
-            f"command line, which has no --export-gcode, --output or --load "
-            f"flag and loads presets as JSON rather than the PrusaSlicer .ini "
-            f"Kiln generates. Kiln cannot drive it yet.\n"
-            f"{_INSTALL_PRUSASLICER}\n"
-            f"Your printer profile and settings are unaffected."
-        )
+    family = slicer_cli_family(slicer)
 
     # Prepare output
-    out_dir = output_dir or _DEFAULT_OUTPUT_DIR
+    out_dir = os.path.abspath(output_dir or _DEFAULT_OUTPUT_DIR)
     os.makedirs(out_dir, mode=0o700, exist_ok=True)
 
     if output_name:
@@ -371,50 +435,70 @@ def slice_file(
         os.unlink(out_file)
 
     # Build command
-    cmd: list[str] = [
-        slicer.path,
-        "--export-gcode",
-        input_abs,
-        "--output",
-        out_file,
-    ]
-
-    if profile:
-        if not os.path.isfile(profile):
-            raise SlicerError(f"Profile file not found: {os.path.basename(profile)}")
-        cmd.extend(["--load", profile])
-
-    if extra_args:
-        cmd.extend(extra_args)
-
-    logger.info("Slicing: %s", " ".join(cmd))
-
-    # Run
+    bambu_work_dir: str | None = None
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired:
-        # Clean up partial output on timeout
-        with contextlib.suppress(OSError):
-            os.unlink(out_file)
-        raise SlicerError(
-            f"Slicing timed out after {timeout}s. The model may be too complex or the slicer is hanging."
-        ) from None
-    except OSError as exc:
-        raise SlicerError(f"Failed to run slicer: {exc}") from exc
+        if family == _CLI_BAMBU:
+            # This CLI names its own output, so it slices into a scratch
+            # directory and the file is moved to out_file afterwards.
+            bambu_work_dir = tempfile.mkdtemp(prefix=".kiln_bambu_", dir=out_dir)
+            cmd = _build_bambu_command(slicer, input_abs, bambu_work_dir, profile)
+        else:
+            cmd = [
+                slicer.path,
+                "--export-gcode",
+                input_abs,
+                "--output",
+                out_file,
+            ]
+            if profile:
+                if not os.path.isfile(profile):
+                    raise SlicerError(f"Profile file not found: {os.path.basename(profile)}")
+                cmd.extend(["--load", profile])
 
-    crashed_after_finishing = (
-        result.returncode != 0
-        and result.returncode < 0  # killed by a signal, not a reported error
-        and _gcode_output_is_complete(out_file)
-    )
-    if result.returncode != 0 and not crashed_after_finishing:
-        stderr_snippet = (result.stderr or "").strip()[:500]
-        raise SlicerError(f"Slicer exited with code {result.returncode}. stderr: {stderr_snippet}")
+        if extra_args:
+            cmd.extend(extra_args)
+
+        logger.info("Slicing: %s", " ".join(cmd))
+
+        # Run
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=bambu_work_dir,
+            )
+        except subprocess.TimeoutExpired:
+            # Clean up partial output on timeout
+            with contextlib.suppress(OSError):
+                os.unlink(out_file)
+            raise SlicerError(
+                f"Slicing timed out after {timeout}s. The model may be too complex or the slicer is hanging."
+            ) from None
+        except OSError as exc:
+            raise SlicerError(f"Failed to run slicer: {exc}") from exc
+
+        crashed_after_finishing = (
+            result.returncode != 0
+            and result.returncode < 0  # killed by a signal, not a reported error
+            and _gcode_output_is_complete(out_file)
+        )
+        if result.returncode != 0 and not crashed_after_finishing:
+            stderr_snippet = (result.stderr or "").strip()[:500]
+            message = f"Slicer exited with code {result.returncode}. stderr: {stderr_snippet}"
+            if not stderr_snippet:
+                # This CLI leaves stderr empty and writes the reason to a log
+                # beside its output, so read that rather than report nothing.
+                detail = _bambu_failure_detail(bambu_work_dir) or (result.stdout or "").strip()
+                message += f" stdout: {detail[:500]}"
+            raise SlicerError(message)
+
+        if bambu_work_dir is not None:
+            _collect_bambu_output(bambu_work_dir, out_file, result.stdout or "")
+    finally:
+        if bambu_work_dir is not None:
+            shutil.rmtree(bambu_work_dir, ignore_errors=True)
 
     # Verify output exists
     if not os.path.isfile(out_file):

--- a/kiln/tests/test_slicer.py
+++ b/kiln/tests/test_slicer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -10,6 +11,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from kiln.slicer import (
+    _build_bambu_command,
+    _collect_bambu_output,
+    _split_bambu_profiles,
     SlicerError,
     SliceResult,
     SlicerInfo,
@@ -718,18 +722,31 @@ class TestSlicerCliFamily:
 
         assert slicer_cli_family(self._info("/x/mystery", None)) == "prusa"
 
-    def test_slice_file_refuses_before_running_the_binary(self, tmp_path):
-        """The refusal names the cause, and never spawns the subprocess."""
+    def test_slice_file_drives_the_bambu_cli(self, tmp_path):
+        """The BambuStudio/OrcaSlicer dialect is built, not refused."""
         from kiln.slicer import SlicerInfo
 
         stl = _write_cube(str(tmp_path / "cube.stl"))
         fake = SlicerInfo(path="/x/OrcaSlicer", name="orcaslicer", version="OrcaSlicer-2.3.2:")
+        seen: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            work = cmd[cmd.index("--outputdir") + 1]
+            with open(os.path.join(work, "plate_1.gcode"), "w") as fh:
+                fh.write("G28\n; filament used [mm] = 1\n")
+            return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("kiln.slicer.find_slicer", return_value=fake), \
-             patch("kiln.slicer.subprocess.run") as ran:
-            with pytest.raises(SlicerError, match="BambuStudio/OrcaSlicer command line"):
-                slice_file(stl, output_dir=str(tmp_path / "out"))
-        ran.assert_not_called()
+             patch("kiln.slicer.subprocess.run", side_effect=fake_run):
+            result = slice_file(stl, output_dir=str(tmp_path / "out"))
+
+        assert result.success is True
+        assert "--slice" in seen["cmd"]
+        assert "--outputdir" in seen["cmd"]
+        assert not {"--export-gcode", "--output", "--load"} & set(seen["cmd"])
+        assert os.path.isfile(result.output_path)
+
 
     def test_not_found_message_no_longer_recommends_orcaslicer(self):
         """It used to send Bambu owners toward the one slicer Kiln cannot drive."""
@@ -761,3 +778,112 @@ class TestRealBinariesClassifyCorrectly:
         if not os.path.isfile(app):
             pytest.skip(f"{os.path.basename(app)} not installed")
         assert slicer_cli_family(find_slicer(app)) == "bambu"
+
+
+# ---------------------------------------------------------------------------
+# BambuStudio/OrcaSlicer backend
+# ---------------------------------------------------------------------------
+
+
+def _bambu(tmp_path):
+    from kiln.slicer import SlicerInfo
+
+    return SlicerInfo(path=str(tmp_path / "OrcaSlicer"), name="orcaslicer", version="OrcaSlicer-2.4.2")
+
+
+def _profile(tmp_path, name: str, kind: str) -> str:
+    """Write a minimal profile JSON declaring *kind* and return its path."""
+    path = tmp_path / name
+    path.write_text(json.dumps({"type": kind, "name": name}))
+    return str(path)
+
+
+class TestBambuProfiles:
+    """Profiles are routed by the type they declare, not by filename."""
+
+    def test_filament_goes_to_its_own_flag(self, tmp_path):
+        machine = _profile(tmp_path, "machine.json", "machine")
+        filament = _profile(tmp_path, "pla.json", "filament")
+
+        settings, filaments = _split_bambu_profiles(f"{machine};{filament}")
+
+        assert settings == [machine]
+        assert filaments == [filament]
+
+    def test_a_prusaslicer_ini_is_rejected_by_name(self, tmp_path):
+        """This CLI exits 251 on an .ini with an empty stderr, so say so here."""
+        ini = tmp_path / "config.ini"
+        ini.write_text("[print]\nlayer_height = 0.2\n")
+
+        with pytest.raises(SlicerError, match="not a bambu profile"):
+            _split_bambu_profiles(str(ini))
+
+    def test_json_that_is_not_a_profile_is_rejected(self, tmp_path):
+        odd = tmp_path / "odd.json"
+        odd.write_text("[]")
+
+        with pytest.raises(SlicerError, match="not a bambu profile"):
+            _split_bambu_profiles(str(odd))
+
+    def test_missing_profile_is_named(self, tmp_path):
+        with pytest.raises(SlicerError, match="Profile file not found"):
+            _split_bambu_profiles(str(tmp_path / "absent.json"))
+
+
+class TestBambuCommand:
+    """The command uses this CLI's flags and keeps the caller's placement."""
+
+    def test_uses_this_dialect_and_not_the_prusaslicer_one(self, tmp_path):
+        machine = _profile(tmp_path, "machine.json", "machine")
+        filament = _profile(tmp_path, "pla.json", "filament")
+
+        cmd = _build_bambu_command(_bambu(tmp_path), "/m/cube.stl", str(tmp_path), f"{machine};{filament}")
+
+        assert cmd[cmd.index("--load-settings") + 1] == machine
+        assert cmd[cmd.index("--load-filaments") + 1] == filament
+        assert cmd[-5:] == ["--slice", "1", "--outputdir", str(tmp_path), "/m/cube.stl"]
+        assert not {"--export-gcode", "--output", "--load"} & set(cmd)
+
+    def test_keeps_the_model_where_the_caller_put_it(self, tmp_path):
+        cmd = _build_bambu_command(_bambu(tmp_path), "/m/cube.stl", str(tmp_path), None)
+
+        assert cmd[cmd.index("--arrange") + 1] == "0"
+
+
+class TestBambuOutput:
+    """The self-named output is moved to the path the caller asked for."""
+
+    def test_moves_the_gcode_and_ignores_other_files(self, tmp_path):
+        work = tmp_path / "work"
+        work.mkdir()
+        (work / "plate_1.png").write_text("thumbnail")
+        (work / "plate_1.gcode").write_text("G28\n")
+        out_file = str(tmp_path / "cube.gcode")
+
+        _collect_bambu_output(str(work), out_file, "")
+
+        assert Path(out_file).read_text() == "G28\n"
+        assert not (work / "plate_1.gcode").exists()
+
+    def test_no_gcode_produced_is_reported_with_the_slicer_output(self, tmp_path):
+        work = tmp_path / "work"
+        work.mkdir()
+
+        with pytest.raises(SlicerError, match="produced no G-code") as exc:
+            _collect_bambu_output(str(work), str(tmp_path / "cube.gcode"), "some stdout")
+
+        assert "some stdout" in str(exc.value)
+
+    def test_scratch_directory_is_removed_when_the_slicer_fails(self, tmp_path):
+        stl = _write_cube(str(tmp_path / "cube.stl"))
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        machine = _profile(tmp_path, "machine.json", "machine")
+
+        with patch("kiln.slicer.find_slicer", return_value=_bambu(tmp_path)), \
+             patch("kiln.slicer.subprocess.run",
+                   return_value=MagicMock(returncode=251, stdout="run found error", stderr="")), \
+             pytest.raises(SlicerError, match="run found error"):
+            slice_file(stl, output_dir=str(out_dir), profile=machine)
+
+        assert list(out_dir.iterdir()) == []


### PR DESCRIPTION
## Summary

`slicer_cli_family()` already tells the BambuStudio/OrcaSlicer binaries apart from PrusaSlicer, and `slice_file()` refuses them, because every command it builds is PrusaSlicer dialect.

This builds the other dialect, so a user whose only slicer is OrcaSlicer or BambuStudio can slice.

## What that CLI needs

1. **It names the output file itself.** It takes `--slice` and a folder given by `--outputdir`, and writes `plate_1.gcode` into it. No flag sets the filename.
2. **Profiles load through two flags.** Machine and process go to `--load-settings`, filament goes to `--load-filaments`.
3. **A filament profile sent to the wrong flag is ignored silently.** It is accepted, ignored, and the slice uses default filament settings. Nothing reports an error.
4. **Failures go to stdout, not stderr.** stderr comes back empty, and the reason is written to a log file beside the output.

## Fix

1. **Build the command for whichever dialect was found.** PrusaSlicer keeps the command it has today, and anything unrecognised still takes that path.
2. **Route each profile by the `type` declared inside it.** Filenames are chosen by the user and do not say what a profile is, so the file's own contents decide. Order does not matter.
3. **Reject a profile this CLI cannot read**, naming the file. A PrusaSlicer `.ini` makes it exit 251 with an empty stderr, which tells the caller nothing.
4. **Read the log file when a run fails**, so the caller sees the reason instead of an exit code alone.
5. **Move the output to the path the caller asked for.** The slice runs in a scratch folder inside the caller's output folder, created inside the same `try` that deletes it, so no failure leaves anything behind. `--slice 1` asks for one plate, matching `slice_file()` returning one path.

## What does not change

1. The PrusaSlicer command is exactly what it was, and a test asserts the full argument list.
2. `slice_file()` keeps its signature, its return type, and writing to the filename the caller chose.
3. Timeout handling, crash salvage, partial-output cleanup and the output check are untouched.
4. The failure message is unchanged whenever stderr has anything in it.

One existing test changes: `test_slice_file_refuses_before_running_the_binary` asserted the refusal this replaces. It now asserts that the command is built and run, and that it carries none of the PrusaSlicer flags.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Refactor (no functional changes)
- [ ] Tests

## Testing

**Against the real OrcaSlicer 2.4.2 binary**, through `slice_file()`:

| What was passed | Before | After |
| --- | --- | --- |
| machine, process and filament JSON | refused | G-code produced |
| a PrusaSlicer `.ini` | refused | error naming the file, slicer never started |
| machine profile only | refused | `process not compatible with printer`, the slicer's own reason |

No scratch folder was left behind in any case. The G-code matches a hand-run slice byte for byte apart from the timestamp in the header, and was printed on a Creality Ender-3 V3 SE.

**Unit tests** (`kiln/tests/test_slicer.py`). The existing tests pass, with the one change noted above. 9 tests added:

1. Profiles route to the correct flag by declared type.
2. A PrusaSlicer `.ini`, JSON that is not a profile, and a missing file are each rejected by name.
3. The command carries this dialect's flags and none of PrusaSlicer's.
4. `--arrange 0` leaves the model where the caller put it.
5. The G-code is moved to the requested path, other files beside it are ignored, no output is reported with the slicer's own text, and the scratch folder is removed when a run fails.

**Full suite.** 12371 passed, 64 failed, 508 skipped. Unmodified `main` in the same environment gives the same 64 failures, with an identical list of failing test IDs; they are environment-dependent tests unrelated to slicing. Nothing here introduces or masks a failure.

**Lint.** `ruff check` reports no problems in `slicer.py`. The test file keeps the 8 findings already on `main` and adds none.

## Checklist

- [x] `pytest` passes for affected package(s)
- [x] No `TODO` in critical paths (print jobs, file upload, temperature control, G-code execution, auth)
- [ ] Docs updated if adding CLI commands, MCP tools, or adapters — not applicable, no new command or tool
- [ ] New adapter implements all `PrinterAdapter` abstract methods (if applicable) — not applicable
- [x] Pre-flight checks not bypassed or weakened
- [x] Temperature and G-code changes validated against safety profiles

This changes how G-code is produced, not how it is checked or sent to a printer, so `preflight_check()` and the validator in `gcode.py` are untouched and still run on the result. Every function added has type hints.
