### PR TITLE
test(emergency): patch once outside threads in concurrent stop/clear

### DIFF
--- a/kiln/tests/test_emergency.py
+++ b/kiln/tests/test_emergency.py
@@ -729,20 +729,22 @@ class TestThreadSafety:
         def _stop_clear(idx: int) -> None:
             try:
                 pid = f"printer-{idx}"
-                with mock.patch.object(coord, "_send_emergency_gcode", return_value=([], [])):
-                    coord.emergency_stop(pid)
+                coord.emergency_stop(pid)
                 coord.clear_stop(pid)
             except Exception as exc:
                 errors.append(str(exc))
 
-        threads = [
-            threading.Thread(target=_stop_clear, args=(i,))
-            for i in range(num_rounds)
-        ]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
+        # Patch once before spawning threads — mock.patch.object is not
+        # thread-safe when applied concurrently from multiple threads.
+        with mock.patch.object(coord, "_send_emergency_gcode", return_value=([], [])):
+            threads = [
+                threading.Thread(target=_stop_clear, args=(i,))
+                for i in range(num_rounds)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
 
         assert errors == []
 


### PR DESCRIPTION
## What

`TestThreadSafety::test_concurrent_stop_and_clear` applied `mock.patch.object` to a **shared** `EmergencyCoordinator` from inside all 20 worker threads. Hoist the patch outside the thread spawn instead.

## Why

`mock._patch.__exit__` calls `delattr` unguarded whenever it recorded the attribute as absent at enter time:

```python
if self.is_local and self.temp_original is not DEFAULT:
    setattr(self.target, self.attribute, self.temp_original)
else:
    delattr(self.target, self.attribute)   # <- no guard
```

`_send_emergency_gcode` is defined on the class, so a thread entering while the instance attribute is unset records `local=False`. When two threads both enter in that window, both take the `delattr` branch and the second raises:

```
'EmergencyCoordinator' object has no attribute '_send_emergency_gcode'
```

That is the harness racing its own patch bookkeeping, not a product defect. `emergency.py` guards its state with a `threading.Lock` and never removes that attribute.

Racing the patch also meant the test was not reliably exercising concurrent stop/clear at all — threads could spend the window fighting over mock's teardown rather than contending on the coordinator. With the patch hoisted, the threads contend on the coordinator, which is what the test claims to cover.

The sibling test 30 lines above, `test_concurrent_stops_all_recorded`, already carries this exact fix and a comment naming the hazard. This applies it to the one case that was left behind.

## Evidence

- Observed on CI: PR #138, `test (3.13)`, [job log](https://github.com/codeofaxel/Kiln/actions/runs/32315155754) — failed with the error above while 3.10/3.11/3.12 passed, on a typing-only dependency bump that cannot affect this code.
- `tests/test_emergency.py`: 62 passed.
- `ruff`: 7 `SIM117` before and after — pre-existing and unchanged by this diff. CI lints `src/` only.

**Caveat:** the flake did not reproduce locally in 350+ trials (local Python is 3.14; CI hit it on 3.13), including with a `threading.Barrier` and a widened overlap window. The mechanism is confirmed from the `mock` source and the CI error string rather than from a local red-to-green.