### PR TITLE
ci: batch routine dependency bumps and cancel superseded PR runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,20 @@ updates:
         patterns:
           - "httpx2"
           - "httpcore2"
+      # Routine lockfile movement, batched into one PR and one CI run. Listed
+      # after http2-stack so that coupled pair still gets its own PR: a
+      # dependency joins the first group whose patterns match it.
+      #
+      # Majors are deliberately excluded and keep arriving one per PR. A major
+      # is the bump that needs to be read on its own -- trimesh 4 -> 5 (#125)
+      # dropped two Python versions and changed two behaviours; that does not
+      # belong in a batch whose whole premise is "these are boring".
+      lockfile-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # pydantic-core is not ours to move. It is a transitive dependency that
       # pydantic pins to an EXACT version (pydantic 2.13.4 requires
@@ -46,9 +60,23 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      lockfile-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
 
+# A new push to a PR branch makes the run already in flight irrelevant, so
+# cancel it rather than pay for a full 3.10-3.13 matrix nobody will read.
+# Scoped to pull_request on purpose: a push to main can be release-adjacent
+# (tags, provenance, publish) and those runs are left to finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Both jobs only read the repo; nothing here writes to GitHub.
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Seven dependency PRs were open at once today, each a one-line `requirements-lock.txt` edit, each paying for its own 3.10–3.13 matrix at ~22 minutes a job. Merging any one of them re-triggered the others. That work was serial for no reason — the bumps are independent and boring.

## Two changes

**`dependabot.yml`: a catch-all minor/patch group per ecosystem.** A week of routine movement now arrives as one PR and one CI run instead of five.

Placement and scope are both load-bearing, and both are verified against the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference):

- The new group is listed **after** `http2-stack`, so that coupled pair keeps its own PR — *"If a dependency matches more than one rule, it's included in the first group that it matches."* Getting this backwards would sweep httpx2/httpcore2 into the batch and resurrect the mutual-blocking deadlock that group exists to prevent (#133, #128).
- **Majors are excluded** via `update-types`, which *"limit[s] the group to one or more semantic versioning levels"*, and *"any outdated dependencies that do not match a rule are updated in individual pull requests."* So majors keep arriving one per PR. That is the point: trimesh 4→5 (#125) dropped two Python versions and changed two behaviours. That is precisely the bump that must not ride along in a batch whose whole premise is "these are boring."

**`ci.yml`: a concurrency group.** There was none, so a new push to a branch started a fresh matrix while the superseded run burned to completion. Scoped to `pull_request` on purpose — a push to `main` can be release-adjacent (tags, provenance, publish), and those runs are left to finish.

## Verification

- Both files parse as YAML; groups resolve to `['http2-stack', 'lockfile-minor-patch']` for `/kiln`, `['lockfile-minor-patch']` for `/octoprint-cli`, `['actions-minor-patch']` for github-actions.
- The three behavioural claims above are quoted from GitHub's docs rather than assumed.

Neither change can be fully proven until the next weekly Dependabot run and the next PR push — config that only takes effect on GitHub's side.