### PR TITLE
Windows: build the crash-signal sets from what the platform defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Kiln starts on Windows again.** 1.4.1.1 failed on every command before it ran — `serve`, `doctor`, even `--help` — because of a Unix-only signal read at startup. Slicing on Windows had the same fault one step further in; both are fixed.
+
 - **The 3D stage opens painted and multicolor 3MF results on every install.** It used to need extra packages most installs never had, so the panel said "preview unavailable" over a file the preview image had already shown correctly.
 - **The 3D preview opens again on a fresh install.** Kiln set up the panel's
   request line but never announced it, so apps that check first showed

--- a/kiln/src/kiln/openscad_runner.py
+++ b/kiln/src/kiln/openscad_runner.py
@@ -97,7 +97,23 @@ from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["OPENSCAD_CRASH_RETURNCODES", "run_openscad"]
+__all__ = ["OPENSCAD_CRASH_RETURNCODES", "present_signals", "run_openscad"]
+
+
+def present_signals(*names: str) -> frozenset[int]:
+    """The numbers of the named signals this platform defines.
+
+    CPython's :mod:`signal` module on Windows has no ``SIGBUS`` and no
+    ``SIGTRAP``; reading either as an attribute raises at import time and
+    takes every ``kiln`` entrypoint down with it (issue #146).  A crash
+    set is built from whatever the platform offers and degrades, on
+    Windows, to ``SIGSEGV`` alone — which is right: the startup race the
+    sets exist for is a macOS libc bug, and a platform that cannot spell
+    the signal cannot produce the crash.
+    """
+    return frozenset(
+        int(sig) for sig in (getattr(signal, name, None) for name in names) if sig is not None
+    )
 
 
 #: Signals treated as "the process crashed on its way up, try again".
@@ -113,7 +129,7 @@ __all__ = ["OPENSCAD_CRASH_RETURNCODES", "run_openscad"]
 #:   that just told us it is out of room.
 #: - ``SIGTERM``/``SIGINT`` are somebody asking for this to stop.
 #:   Restarting it is the opposite of what was asked.
-_CRASH_SIGNALS = frozenset({signal.SIGSEGV, signal.SIGBUS})
+_CRASH_SIGNALS = present_signals("SIGSEGV", "SIGBUS")
 
 #: Return codes that mean one of :data:`_CRASH_SIGNALS` killed the child.
 #:
@@ -123,7 +139,7 @@ _CRASH_SIGNALS = frozenset({signal.SIGSEGV, signal.SIGBUS})
 #: :mod:`kiln.slicer` carries them: cheap, and correct if a caller ever
 #: hands a result from elsewhere to :func:`crashed_on_startup`.
 OPENSCAD_CRASH_RETURNCODES = frozenset(
-    {-int(sig) for sig in _CRASH_SIGNALS} | {128 + int(sig) for sig in _CRASH_SIGNALS}
+    {-sig for sig in _CRASH_SIGNALS} | {128 + sig for sig in _CRASH_SIGNALS}
 )
 
 #: How long a run may take and still be blamed on the startup race.

--- a/kiln/src/kiln/slicer.py
+++ b/kiln/src/kiln/slicer.py
@@ -31,7 +31,6 @@ import logging
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
@@ -40,6 +39,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from kiln.openscad_runner import present_signals
 from kiln.slicer_orca import (
     PRIME_TOWER_WIDTH_MM,
     ini_to_settings,
@@ -405,9 +405,9 @@ _ORCA_SIGSEGV_RETURNCODES = frozenset({-11, 139})
 # retried.  SIGSEGV/SIGBUS ride along because the OpenSCAD twin showed
 # one underlying race spelling itself as either a libc guard trap or a
 # wild read, depending on where the torn pointer lands.
-_SLIC3R_STARTUP_CRASH_RETURNCODES = frozenset({
-    -int(signal.SIGTRAP), -int(signal.SIGSEGV), -int(signal.SIGBUS),
-})
+_SLIC3R_STARTUP_CRASH_RETURNCODES = frozenset(
+    -sig for sig in present_signals("SIGTRAP", "SIGSEGV", "SIGBUS")
+)
 
 # The Orca dialect keeps SIGSEGV out of its retry set on purpose: -11 on
 # that path is the deterministic Bambu-preset crash above, a real verdict
@@ -416,9 +416,9 @@ _SLIC3R_STARTUP_CRASH_RETURNCODES = frozenset({
 # not retrying real answers).  The locale race has not been captured on
 # an Orca binary; TRAP/BUS are covered so that if it ever is, the user
 # gets the re-draw instead of the failure.
-_ORCA_STARTUP_CRASH_RETURNCODES = frozenset({
-    -int(signal.SIGTRAP), -int(signal.SIGBUS),
-})
+_ORCA_STARTUP_CRASH_RETURNCODES = frozenset(
+    -sig for sig in present_signals("SIGTRAP", "SIGBUS")
+)
 
 #: A crash later than this is blamed on the model, not on startup.  The
 #: observed crashes die in the first ~0.1s; ten seconds is far past any

--- a/kiln/tests/test_openscad_runner.py
+++ b/kiln/tests/test_openscad_runner.py
@@ -499,3 +499,64 @@ class TestLocaleHypothesisNotShipped:
             "and not demonstrated to help — see the module docstring."
         )
         assert os.environ["LC_ALL"] == "en_US.UTF-8"
+
+
+# ---------------------------------------------------------------------------
+# Windows: the crash sets must build on a signal module without SIGBUS
+# ---------------------------------------------------------------------------
+
+#: The Unix-only signals the crash sets name.  CPython's ``signal`` module
+#: on Windows defines neither, so any module that reads them at import
+#: time cannot be imported there at all.
+_UNIX_ONLY_SIGNALS = ("SIGBUS", "SIGTRAP")
+
+_WINDOWS_SHAPED_IMPORT = f"""
+import json, signal
+for name in {_UNIX_ONLY_SIGNALS!r}:
+    delattr(signal, name)
+import kiln.cli.main
+import kiln.openscad_runner as runner
+import kiln.slicer as slicer
+print(json.dumps({{
+    "openscad": sorted(runner.OPENSCAD_CRASH_RETURNCODES),
+    "slic3r": sorted(slicer._SLIC3R_STARTUP_CRASH_RETURNCODES),
+    "orca": sorted(slicer._ORCA_STARTUP_CRASH_RETURNCODES),
+}}))
+"""
+
+
+class TestImportsOnWindowsShapedSignalModule:
+    """Issue #146: ``kiln`` could not start on Windows.
+
+    ``signal.SIGBUS`` is Unix-only and was read at module import time, so
+    every entrypoint — ``kiln serve``, ``kiln doctor``, ``kiln --help`` —
+    died with ``AttributeError`` before running a command.  ``kiln.slicer``
+    carried the same fault twice over (``SIGTRAP`` and ``SIGBUS``), one
+    lazy import further down the same road.
+
+    The Windows signal module is simulated in a child interpreter by
+    deleting the two attributes before the package is imported: that is
+    exactly the shape of the failure, and nothing in this process has to
+    be reloaded.  The sets are expected to degrade to what remains,
+    ``SIGSEGV``, not to vanish.
+    """
+
+    def test_every_entrypoint_imports_and_the_sets_degrade(self):
+        proc = subprocess.run(
+            [sys.executable, "-c", _WINDOWS_SHAPED_IMPORT],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=os.environ,
+        )
+        assert proc.returncode == 0, (
+            "import failed on a signal module without SIGBUS/SIGTRAP:\n"
+            + proc.stderr[-2000:]
+        )
+        import json
+
+        sets = json.loads(proc.stdout.strip().splitlines()[-1])
+        segv = int(signal.SIGSEGV)
+        assert sets["openscad"] == sorted({-segv, 128 + segv})
+        assert sets["slic3r"] == [-segv]
+        assert sets["orca"] == []


### PR DESCRIPTION
Fixes #146.

CPython's `signal` module on Windows has no `SIGBUS` and no `SIGTRAP`. `openscad_runner` read `SIGBUS` at import time, and `kiln.cli.main` reaches it through `kiln.generation`, so every entrypoint (`serve`, `doctor`, `--help`) died with `AttributeError` on 1.4.1.1. `kiln.slicer` carried the same fault twice over, one lazy import further down: the first slice would have hit it next.

One helper now names the signals and keeps whichever exist. On Windows the sets degrade to `SIGSEGV` alone, which is right: the startup race they exist for is a macOS libc bug.

The regression test simulates the Windows signal module in a child interpreter and imports every door (`kiln.cli.main`, `openscad_runner`, `slicer`). It fails before this change with the reporter's exact traceback and passes after.