### PR TITLE
changelog: credit the Windows startup-crash reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- **Kiln starts on Windows again.** 1.4.1.1 failed on every command before it ran — `serve`, `doctor`, even `--help` — because of a Unix-only signal read at startup. Slicing on Windows had the same fault one step further in; both are fixed.
+- **Kiln starts on Windows again.** 1.4.1.1 failed on every command before it ran — `serve`, `doctor`, even `--help` — because of a Unix-only signal read at startup. Slicing on Windows had the same fault one step further in; both are fixed. Thanks [@AsteisesDev](https://github.com/AsteisesDev), who reported it on Windows 11 with the cause pinned, and suggested the sweep that turned up the second one.
 
 - **The 3D stage opens painted and multicolor 3MF results on every install.** It used to need extra packages most installs never had, so the panel said "preview unavailable" over a file the preview image had already shown correctly.
 - **The 3D preview opens again on a fresh install.** Kiln set up the panel's


### PR DESCRIPTION
Adds a reporter credit to the Windows entry in `[Unreleased]`, matching the house pattern already used for earlier contributors.

The suggestion to grep for sibling Unix-only attributes is what found the second site in the slicer, so the credit says that rather than just "thanks for the report".

🤖 Generated with [Claude Code](https://claude.com/claude-code)