### PR TITLE
Public surfaces describe outcomes, not internals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,19 @@ jobs:
         if: ${{ !cancelled() && steps.deps.outcome == 'success' }}
         run: cd octoprint-cli && python -m pytest tests/ -v --cov=octoprint_cli --cov-report=term-missing
 
+      - name: Served-surface leak gate
+        if: ${{ !cancelled() && steps.deps.outcome == 'success' }}
+        # Builds the free-install MCP registry in-process (kiln-pro blocked, so
+        # the paid-tool discovery stubs appear as a free user gets them), walks
+        # `kiln --help`, and reads the bundled manifest and data notes — every
+        # text a client receives verbatim.  Fails on wording that names how the
+        # paid depth is built (private paths, docket numbers, bibliographies,
+        # field inventories, the internal label) rather than what a tier
+        # unlocks.  Added after the 2026-09-02 sweep found 91 served tool
+        # descriptions carrying exactly that while the source gates stayed
+        # green.  Exit 2 = leak, 3 = registry failed to load.
+        run: cd kiln && PYTHONPATH=src python ../scripts/audit_served_surface_leak.py
+
       - name: Generate SBOM (CycloneDX)
         if: ${{ !cancelled() && steps.deps.outcome == 'success' && matrix.python-version == '3.12' }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ scripts/*
 # test so public source can never ship a curated cross-vendor capability /
 # SME table (the moat belongs in the private tier or a pro overlay).
 !scripts/audit_public_sme_leak.py
+# …and for the tool-description dump, which writes every tool / prompt /
+# resource description the MCP server hands to clients to one file so the
+# public-surface sweeps have something to grep.
+!scripts/dump_tool_descriptions.py
 # …and for the public-language gate, which checks tracked text and new
 # commit messages for private editorial context before it reaches GitHub.
 !scripts/check_public_language.py

--- a/.gitignore
+++ b/.gitignore
@@ -66,13 +66,15 @@ scripts/*
 # test so public source can never ship a curated cross-vendor capability /
 # SME table (the moat belongs in the private tier or a pro overlay).
 !scripts/audit_public_sme_leak.py
-# …and for the tool-description dump, which writes every tool / prompt /
-# resource description the MCP server hands to clients to one file so the
-# public-surface sweeps have something to grep.
-!scripts/dump_tool_descriptions.py
 # …and for the public-language gate, which checks tracked text and new
 # commit messages for private editorial context before it reaches GitHub.
 !scripts/check_public_language.py
+# …and for the served-surface leak gate plus the dump it is built on: every
+# tool / prompt / resource description, CLI help text, manifest entry, and
+# data note a client or `kiln --help` reader receives, judged for wording
+# that names how the paid depth is built instead of what a tier unlocks.
+!scripts/audit_served_surface_leak.py
+!scripts/dump_tool_descriptions.py
 # …and for the tool-door param-parity gate, which is run by a CI-collected
 # test so a tuned engine axis (material, printer_id) can never be silently
 # unreachable through the @mcp.tool() door an agent actually calls.

--- a/kiln/src/kiln/cli/auth_commands.py
+++ b/kiln/src/kiln/cli/auth_commands.py
@@ -383,8 +383,8 @@ def auth_login(no_browser: bool, timeout: int, provider: str | None) -> None:
 def auth_logout() -> None:
     """Delete the locally-stored Kiln session token.
 
-    This does not revoke the token upstream — Supabase-side revocation
-    lives in the workshop (``/settings/account → Sign out of all
+    This does not revoke the session everywhere — to sign out of every
+    device, use the web app (``Settings → Account → Sign out of all
     sessions``).  For most users this command is what they want: it
     forgets the session on this laptop without touching the others.
     """

--- a/kiln/src/kiln/cli/main.py
+++ b/kiln/src/kiln/cli/main.py
@@ -9033,7 +9033,7 @@ def local_first_cmd(apply: bool, write_env: bool, json_mode: bool) -> None:
         "env_file": env_file_path,
         "notes": [
             "This profile is privacy-first and local-first by default.",
-            "No print content or model payloads are sent to Supabase licensing tables.",
+            "No print content or model payloads are sent to Kiln's licensing service.",
             "If you use cloud LLMs, set KILN_OPENROUTER_KEY explicitly.",
         ],
     }
@@ -11035,16 +11035,15 @@ def goals_list(filter_status: str, limit: int, json_mode: bool) -> None:
     inbox: shows what you've committed and which prints have honored
     each goal.
 
-    Requires kiln-pro (the design_session lifecycle lives there).
+    Requires Kiln Pro.
     """
     try:
         from kiln_pro.design_brief import list_briefs
     except ImportError:
         click.echo(
             format_error(
-                "Saved goals require Kiln Pro (the design_session lifecycle "
-                "and its DesignBrief store live in kiln-pro). Install with: "
-                "pip install kiln-pro — or upgrade at https://kiln3d.com/pricing",
+                "Saved goals are a Kiln Pro feature. Already subscribed? Run "
+                "`kiln signin` on this machine. New? https://kiln3d.com/pricing",
                 code="REQUIRES_KILN_PRO",
                 json_mode=json_mode,
             )

--- a/kiln/src/kiln/data/design_knowledge/design_templates.json
+++ b/kiln/src/kiln/data/design_knowledge/design_templates.json
@@ -2,7 +2,7 @@
   "_meta": {
     "version": "2.0.0",
     "domain": "fdm",
-    "description": "Discovery catalog of functional design templates for FDM printing. Each entry is identifiable by display_name, use_cases, and material compatibility — enough for an agent to surface the right template to the user. Engineering-grade depth (design_rules, agent_guidance, failure modes, structured variants, sources) lives in the Kiln Pro overlay.",
+    "description": "Discovery catalog of functional design templates for FDM printing. Each entry is identifiable by display_name, use_cases, and material compatibility — enough for an agent to surface the right template to the user. Engineering-grade depth for each template is available in Kiln Pro.",
     "_data_quality": {
       "last_audit_date": "2026-05-05",
       "primary_sources": [

--- a/kiln/src/kiln/data/design_knowledge/design_templates.json
+++ b/kiln/src/kiln/data/design_knowledge/design_templates.json
@@ -6,16 +6,13 @@
     "_data_quality": {
       "last_audit_date": "2026-05-05",
       "primary_sources": [
-        "Bayer 'Snap-Fit Joint Design' Engineering Polymers Design Guide (1995)",
-        "Shigley & Mischke 'Mechanical Engineering Design' 10th ed.",
-        "ISO 261 / ISO 286 / ISO 60529 / ISO 60715 / ISO 62133 — relevant standards",
-        "AGMA 933 — Basic Gear Geometry",
+        "Published mechanical-design references and international standards",
         "Manufacturer technical datasheets and published catalogs",
         "Empirical FDM community consensus"
-      ],
+       ],
       "methodology": "Conservative safety-floor values appropriate for AI-controlled FDM printing without expert supervision. Deeper curated engineering values ship in Kiln Pro."
     },
-    "_split_note": "Discovery + safety-floor profiles for AI-controlled FDM printing. Curated engineering depth (recommended dimensions, structured failure modes, decision trees, holding torques, cycle estimates, helical-gear formulas, IP-rating decision trees, captured-ball variants, anti-walkout lock options, per-material insert tables, DIN-rail variants, and source-cited reasoning) is available in Kiln Pro. See https://kiln3d.com/pricing."
+    "_split_note": "Discovery + safety-floor profiles for AI-controlled FDM printing. Curated engineering depth for every template is available in Kiln Pro. See https://kiln3d.com/pricing."
   },
   "snap_fit_cantilever": {
     "display_name": "Cantilever Snap Fit",

--- a/kiln/src/kiln/data/design_knowledge/environment_compatibility.json
+++ b/kiln/src/kiln/data/design_knowledge/environment_compatibility.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Material survival matrix for environment and exposure checks. Ratings are qualitative and intended for fast agent triage before geometry generation.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (per-block notes + cycle_life_estimates) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Deeper per-material guidance is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "uv_resistance": {

--- a/kiln/src/kiln/data/design_knowledge/functional_requirements.json
+++ b/kiln/src/kiln/data/design_knowledge/functional_requirements.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Maps functional requirements to design constraints. When an agent describes what an object needs to DO, these rules translate into what the design needs to BE.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (agent_guidance worked examples) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Worked design guidance is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "load_bearing": {
     "display_name": "Supports Weight / Load-Bearing",

--- a/kiln/src/kiln/data/design_knowledge/load_tables.json
+++ b/kiln/src/kiln/data/design_knowledge/load_tables.json
@@ -4,7 +4,7 @@
     "domain": "fdm",
     "description": "Per-material safe-load lookup for cantilevered FDM parts, DERIVED (not hand-authored): safe_load_N = tensile_capacity_n_per_mm2 x (A^1.5/6) / L, where tensile_capacity = catalogue tensile x 0.9 FDM print factor / 3.0 safety factor. SQUARE cross-section basis \u2014 wide or flat sections are weaker. Regenerate with kiln/scripts/generate_load_tables.py; never hand-edit values.",
     "_orientation_convention": "layer_orientation_derating keys: 'across_layers' = the load pulls the layer interfaces apart (build/Z direction \u2014 the WEAK case for FDM; factor 0.4, the worst per-material interlayer ratio so one conservative pair covers every material). 'along_layers' = the load acts within the layer planes (the STRONG case; factor 1.0). Per-material anisotropy depth lives in Kiln Pro.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (per-material SME caveats) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-material engineering caveats are available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "tensile_capacity_n_per_mm2": 15.0,

--- a/kiln/src/kiln/data/design_knowledge/material_troubleshooting.json
+++ b/kiln/src/kiln/data/design_knowledge/material_troubleshooting.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Per-material troubleshooting: common print failures, root causes, and specific fixes. Agent-consumable for real-time print diagnostics.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (common_issues playbooks + break_in_tips) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-symptom diagnostic playbooks are available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "storage_requirements": {

--- a/kiln/src/kiln/data/design_knowledge/materials.json
+++ b/kiln/src/kiln/data/design_knowledge/materials.json
@@ -13,7 +13,7 @@
       "update_cadence": "annual for established materials (PLA, PETG, ABS), semi-annual for newer composites (CF-Nylon, PA6-GF, PET-CF); high-performance polymers (PEI, PEEK, PEKK, PPSU, PPS) annual — their datasheets change rarely, but vendor process windows do",
       "methodology": "Conservative/worst-case values used for composites where manufacturer specs vary. Mechanical values represent typical FDM-printed properties (not injection-molded datasheets). Design limits empirically validated where possible."
     },
-    "_split_note": "Safety-floor profiles for AI-controlled FDM printing.  Engineering-grade properties (mechanical, design limits, use-case ratings, brand tuning, curated guidance) are available in Kiln Pro.  See https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profiles for AI-controlled FDM printing.  Engineering-grade material depth is available in Kiln Pro.  See https://kiln3d.com/pricing."
   },
   "pla": {
     "display_name": "PLA (Polylactic Acid)",

--- a/kiln/src/kiln/data/design_knowledge/multi_material_pairing.json
+++ b/kiln/src/kiln/data/design_knowledge/multi_material_pairing.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Dual-extrusion and multi-material compatibility rules. Which materials can be printed together, support dissolution methods, and interface adhesion.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (pair notes + co_print notes + general polymer-class rules) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-pair printing guidance is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "support_pairs": [
     {

--- a/kiln/src/kiln/data/design_knowledge/post_processing.json
+++ b/kiln/src/kiln/data/design_knowledge/post_processing.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Post-processing techniques per material. Surface finishing, strengthening, and aesthetic treatments with specific procedures.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (technique procedures + paintability prose + strengthening tradeoffs) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Step-by-step procedures and strengthening tradeoffs are available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "techniques": [

--- a/kiln/src/kiln/data/design_knowledge/printer_material_compatibility.json
+++ b/kiln/src/kiln/data/design_knowledge/printer_material_compatibility.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Printer-to-material compatibility matrix. Maps which materials each printer can handle out-of-box, with upgrades, or not at all.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (per-(printer, material) curated notes) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-printer, per-material notes are available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "anker_m5": {
     "pla": {

--- a/kiln/src/kiln/data/design_knowledge/printer_profiles.json
+++ b/kiln/src/kiln/data/design_knowledge/printer_profiles.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Desktop printer capability profiles for material feasibility and design-for-manufacturing decisions.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (agent_notes positioning prose) is available in Kiln Pro; see https://kiln3d.com/pricing.",
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-printer positioning guidance is available in Kiln Pro; see https://kiln3d.com/pricing.",
     "_default_profile_note": "The 'default' entry is the deliberately conservative stand-in for a printer Kiln has no profile for. Its numbers are the floor a commodity FDM machine can be assumed to meet, NOT a measurement of any product, so a feasibility answer given against it is the answer for the least capable plausible machine. Register the real printer to get a real answer."
   },
   "default": {

--- a/kiln/src/kiln/data/printer_intelligence.json
+++ b/kiln/src/kiln/data/printer_intelligence.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Printer intelligence database: firmware quirks, material compatibility, calibration guidance, and known failure modes. Keyed by the same printer_id as safety_profiles.json.",
     "updated": "2025-02-11",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (quirks + calibration recipes + failure_modes + per-material notes) is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-printer quirks, calibration recipes, and failure-mode playbooks are available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "default": {
     "display_name": "Generic FDM Printer",

--- a/kiln/src/kiln/design_intelligence.py
+++ b/kiln/src/kiln/design_intelligence.py
@@ -904,7 +904,8 @@ class _DesignKnowledgeBase:
         self._skin_contact: dict[str, dict[str, Any]] = {}
         # Each table's ``_meta`` block, keyed by table attribute.  The tables
         # themselves drop every underscore key (that rule keeps metadata and
-        # paid-tier fields out of the merged material dicts), so curated table-level policy —
+        # paid-tier fields out of the merged material dicts), so curated
+        # table-level policy —
         # which is legitimately public — would otherwise be unreachable.
         self._table_meta: dict[str, dict[str, Any]] = {}
         #: Overlay kind -> ``(the overlay payload that was merged, the merged

--- a/kiln/src/kiln/design_intelligence.py
+++ b/kiln/src/kiln/design_intelligence.py
@@ -903,8 +903,8 @@ class _DesignKnowledgeBase:
         self._multi_material: dict[str, Any] = {}
         self._skin_contact: dict[str, dict[str, Any]] = {}
         # Each table's ``_meta`` block, keyed by table attribute.  The tables
-        # themselves drop every underscore key (that rule keeps meta and moat
-        # out of the merged material dicts), so curated table-level policy —
+        # themselves drop every underscore key (that rule keeps metadata and
+        # paid-tier fields out of the merged material dicts), so curated table-level policy —
         # which is legitimately public — would otherwise be unreachable.
         self._table_meta: dict[str, dict[str, Any]] = {}
         #: Overlay kind -> ``(the overlay payload that was merged, the merged
@@ -1075,7 +1075,7 @@ class _DesignKnowledgeBase:
     @property
     def skin_contact_meta(self) -> dict[str, Any]:
         """Table-level skin-contact policy: family inheritance + the generic
-        uncharacterized floor.  Public curated copy, not moat."""
+        uncharacterized floor.  Public curated copy; ships at every tier."""
         self._load()
         return self._table_meta.get("_skin_contact", {})
 

--- a/kiln/src/kiln/failure_vocabulary.py
+++ b/kiln/src/kiln/failure_vocabulary.py
@@ -280,7 +280,7 @@ def mitigation_for(mode: str | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Negative-constraint anti-patterns (KILN-010 claim 62)
+# Negative-constraint anti-patterns
 # ---------------------------------------------------------------------------
 
 # Symmetric counterpart to MITIGATIONS: short clauses describing what

--- a/kiln/src/kiln/generation_feedback.py
+++ b/kiln/src/kiln/generation_feedback.py
@@ -25,11 +25,11 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Prompt sanity gate (KILN-010 claim 51)
+# Prompt sanity gate
 # ---------------------------------------------------------------------------
 
 # Minimum fraction of original-prompt tokens that must survive into the
-# improved prompt, per claim 51's "at least 70 percent token overlap".
+# improved prompt, so the improved prompt still carries the original intent.
 _MIN_TOKEN_OVERLAP_PCT = 0.70
 
 # Detects "minimum X 2.5mm" / "max X 30 degrees" style numeric clauses.
@@ -312,7 +312,7 @@ class PrintFeedback:
 
 
 class SanityFailureKind(str, enum.Enum):
-    """Categories of sanity-gate violations (KILN-010 claim 51)."""
+    """Categories of sanity-gate violations."""
 
     CONTRADICTION = "contradiction"
     BUDGET = "budget"
@@ -337,7 +337,7 @@ class SanityFailure:
 
 @dataclass
 class SanityResult:
-    """Sanity-gate verdict for an improved prompt (KILN-010 claim 51).
+    """Sanity-gate verdict for an improved prompt.
 
     Three checks: no contradictions between constraints, prompt fits the
     provider budget, and at least 70% token overlap between the improved
@@ -521,9 +521,9 @@ def check_prompt_sanity(
     budget: int,
     min_token_overlap: float = _MIN_TOKEN_OVERLAP_PCT,
 ) -> SanityResult:
-    """Run the three-check sanity gate from KILN-010 claim 51.
+    """Run the three-check sanity gate.
 
-    The gate is a deterministic stand-in for the patent's "second model"
+    The gate is a deterministic stand-in for a second reviewing model
     — it catches the contradiction shapes a model would catch, plus the
     cheaper budget and intent-overlap checks.  Callers re-generate when
     the result is not ``passed``.
@@ -533,7 +533,7 @@ def check_prompt_sanity(
     :param budget: Maximum prompt length the provider will accept.
     :param min_token_overlap: Minimum fraction of original tokens that
         must appear in the improved prompt's intent prefix.  Defaults to
-        the patent's 0.70 threshold.
+        0.70.
     :returns: A :class:`SanityResult` summarising the verdict.
     """
     failures: list[SanityFailure] = []
@@ -1398,7 +1398,7 @@ def enhance_prompt_with_design_intelligence(
         auto-resolved material and printer-specific failure mitigations
         are included in the prompt.
     :param anti_patterns: Optional list of explicit anti-pattern clauses
-        to inject as ``Avoid:`` guidance (KILN-010 claim 62).  When
+        to inject as ``Avoid:`` guidance.  When
         omitted, anti-patterns are derived from
         ``printer_context.common_failures`` via
         :func:`kiln.failure_vocabulary.anti_pattern_for`.
@@ -1619,7 +1619,7 @@ def enhance_prompt_with_design_intelligence(
     else:
         constraints = core_constraints
 
-    # Negative-constraint anti-patterns (KILN-010 claim 62) — explicit
+    # Negative-constraint anti-patterns — explicit
     # exclusions of patterns known to cause failures for the current
     # (material, printer) context.  Caller-supplied ``anti_patterns``
     # take precedence; otherwise derive from the printer's recurring

--- a/kiln/src/kiln/generation_feedback.py
+++ b/kiln/src/kiln/generation_feedback.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 # Minimum fraction of original-prompt tokens that must survive into the
-# improved prompt, so the improved prompt still carries the original intent.
+# improved prompt, so the result still carries the original intent.
 _MIN_TOKEN_OVERLAP_PCT = 0.70
 
 # Detects "minimum X 2.5mm" / "max X 30 degrees" style numeric clauses.

--- a/kiln/src/kiln/image_to_surface.py
+++ b/kiln/src/kiln/image_to_surface.py
@@ -1772,9 +1772,6 @@ def generate_qr_data(content: str, output_dir: str) -> dict:
     QR code decoration is a paid feature. The implementation lives in
     the kiln-pro package. This stub raises ImportError to direct users
     to the tier that actually includes it.
-
-    See ``kiln_pro.decoration.qr_decorator.generate_qr_data`` for the
-    real implementation.
     """
     raise ImportError(
         "QR code decoration is a Business feature. "

--- a/kiln/src/kiln/multicolor_3mf.py
+++ b/kiln/src/kiln/multicolor_3mf.py
@@ -1027,8 +1027,8 @@ def auto_arrange_parts(
     the same XY position (they overlap intentionally, like body + QR pads).
     Different groups are spaced apart.
 
-    For smart 2D bin-packing that maximises plate density, upgrade to
-    kiln-pro (``from kiln_pro.plate_optimizer import smart_arrange``).
+    For smart 2D bin-packing that maximises plate density, use Kiln Pro's
+    ``auto_arrange_parts_on_plate``.
 
     Args:
         part_specs: List of dicts, each with:

--- a/kiln/src/kiln/plugins/recovery_tools.py
+++ b/kiln/src/kiln/plugins/recovery_tools.py
@@ -574,8 +574,7 @@ class _RecoveryToolsPlugin:
             printability and structural issues, without modifying the
             creative intent.
 
-            Patent KILN-010 claim 51 — the improved prompt is run
-            through a three-check sanity gate (no contradictions, fits
+            The improved prompt is run through a three-check sanity gate (no contradictions, fits
             the provider budget, ≥70% original-token overlap so intent
             is preserved).  When ``enforce_sanity=True`` (default) and
             the gate fails, this tool refuses with
@@ -651,7 +650,7 @@ class _RecoveryToolsPlugin:
                     iteration=iteration,
                 )
 
-                # KILN-010 claim 51: refuse contradictory / over-budget /
+                # Sanity gate: refuse contradictory / over-budget /
                 # intent-drifted prompts before they reach the generator.
                 # The agent gets the failure list and the would-be
                 # prompt so it can pick a repair strategy (drop a
@@ -1160,7 +1159,7 @@ class _RecoveryToolsPlugin:
                     ``build_volume_mm``, ``success_rate``).  When
                     supplied alongside ``success=False``, the response
                     will include a ``reroute_recommendation`` from the
-                    pro rerouter (patent KILN-003 claim 5).  Single-printer
+                    Pro rerouter.  Single-printer
                     setups can omit this.
                 completion_pct_at_failure: How far the failed print got
                     (0.0–1.0).  Below 10% the rerouter prefers
@@ -1280,7 +1279,7 @@ class _RecoveryToolsPlugin:
                 except ImportError:
                     return response
             except MonitoringThresholdNotMet as exc:
-                # Patent claim 79: structured error includes the deficit
+                # The structured error includes the deficit
                 # so the orchestrator/UI can prompt for additional checks.
                 err = _srv._error_dict(str(exc), code=exc.to_dict()["code"])
                 err.update(exc.to_dict())

--- a/kiln/src/kiln/plugins/recovery_tools.py
+++ b/kiln/src/kiln/plugins/recovery_tools.py
@@ -574,8 +574,8 @@ class _RecoveryToolsPlugin:
             printability and structural issues, without modifying the
             creative intent.
 
-            The improved prompt is run through a three-check sanity gate (no contradictions, fits
-            the provider budget, ≥70% original-token overlap so intent
+            The improved prompt is run through a three-check sanity gate
+            (no contradictions, fits the provider budget, ≥70% original-token overlap so intent
             is preserved).  When ``enforce_sanity=True`` (default) and
             the gate fails, this tool refuses with
             ``code="SANITY_GATE_FAILED"`` and returns the failure list

--- a/kiln/src/kiln/print_health_monitor.py
+++ b/kiln/src/kiln/print_health_monitor.py
@@ -1275,7 +1275,7 @@ class PrintHealthMonitor:
                         pause_fired_this_tick = True
 
                 # Pro-tier predictive risk — score the recent health
-                # reports against KILN-003 thermal/flow/layer-time
+                # reports against the thermal/flow/layer-time
                 # heuristics.  Red signals get surfaced into the issue
                 # stream so they sit alongside vision-based and
                 # health-based detections.  Best-effort and signal-only:

--- a/kiln/src/kiln/print_recovery.py
+++ b/kiln/src/kiln/print_recovery.py
@@ -65,7 +65,7 @@ _TEMP_DROP_ADHESION_THRESHOLD = 10.0
 _SPAGHETTI_EXTRUSION_RATIO_MIN = 0.2
 _WARPING_TEMP_GRADIENT_MAX = 5.0  # degrees across bed
 
-# Per patent claim 78: the monitoring-checks-required threshold is
+# The monitoring-checks-required threshold is
 # resolved from the failure severity at session-creation time.
 # Critical failures (thermal runaway, bed adhesion) demand more passing
 # observations before recovery may be declared COMPLETED.
@@ -340,11 +340,10 @@ class RecoverySession:
 
 class MonitoringThresholdNotMet(ValueError):
     """Raised when ``complete_recovery(success=True)`` is called before
-    ``monitoring_passed >= monitoring_required`` (patent claim 76).
+    ``monitoring_passed >= monitoring_required``.
 
     Subclasses :class:`ValueError` so existing handlers still catch it,
-    but exposes structured fields for the MCP tool wrapper to surface
-    per claim 79.
+    but exposes structured fields for the MCP tool wrapper to surface.
     """
 
     def __init__(
@@ -819,7 +818,7 @@ class PrintRecovery:
                 raise ValueError(
                     f"Session {session_id!r} is already in terminal state: {session.status.value}"
                 )
-            # Patent claim 76: success completion requires the
+            # Success completion requires the
             # monitoring-checks threshold to be met. Failure completion is
             # always allowed (operator may give up at any time).
             if success and session.monitoring_passed < session.monitoring_required:

--- a/kiln/src/kiln/pro_tool_manifest.json
+++ b/kiln/src/kiln/pro_tool_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated": "2026-09-01T23:28:28.871577+00:00",
+  "generated": "2026-09-02T08:01:40.151958+00:00",
   "tool_count": 417,
   "categories": {
     "product_generators": {
@@ -4320,7 +4320,7 @@
     },
     {
       "name": "cherry_pick_modification",
-      "description": "Apply one isolated semantic modification from a source branch onto a target branch (KILN-021 Priority 13). Opens Kiln's interactive inline 3D stage on the result (orbit/zoom panel in MCP Apps hosts; hosted sessions add a browser stage link).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
+      "description": "Apply one isolated semantic modification from a source branch onto a target branch. Opens Kiln's interactive inline 3D stage on the result (orbit/zoom panel in MCP Apps hosts; hosted sessions add a browser stage link).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
       "tier": "pro",
       "access": "pro",
       "category": "design_versioning",
@@ -4367,7 +4367,7 @@
     },
     {
       "name": "compare_branches",
-      "description": "Render a side-by-side comparison of two branches as a Mermaid ``sequenceDiagram`` (KILN-028 merge-preview).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
+      "description": "Render a side-by-side comparison of two branches as a Mermaid ``sequenceDiagram``.\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
       "tier": "pro",
       "access": "pro",
       "category": "design_versioning",
@@ -6252,7 +6252,7 @@
     },
     {
       "name": "merge_feature_branches",
-      "description": "Record a merge \u2014 ``a = source.head``, ``b = target.head`` (bug-X2 correct). Opens Kiln's interactive inline 3D stage on the result (orbit/zoom panel in MCP Apps hosts; hosted sessions add a browser stage link).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
+      "description": "Record a merge \u2014 ``a = source.head``, ``b = target.head``. Opens Kiln's interactive inline 3D stage on the result (orbit/zoom panel in MCP Apps hosts; hosted sessions add a browser stage link).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
       "tier": "pro",
       "access": "pro",
       "category": "design_versioning",
@@ -6512,7 +6512,7 @@
     },
     {
       "name": "push_reflog_to_cloud",
-      "description": "Mirror local reflog entries up to the tenant's cloud reflog (``kiln_cloud_reflog``).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
+      "description": "Mirror local reflog entries up to the tenant's cloud reflog.\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
       "tier": "pro",
       "access": "pro",
       "category": "design_versioning",
@@ -7622,7 +7622,7 @@
     },
     {
       "name": "show_design_lineage",
-      "description": "Show the full lineage of a design as a Mermaid ``flowchart TD`` with outcomes emphasized (KILN-021 native).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
+      "description": "Show the full lineage of a design as a Mermaid ``flowchart TD`` with outcomes emphasized.\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
       "tier": "pro",
       "access": "pro",
       "category": "design_versioning",
@@ -7990,7 +7990,7 @@
     },
     {
       "name": "source_merge_three_way",
-      "description": "Three-way OpenSCAD source merge (KILN-021 Priority 9 fallback).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
+      "description": "Three-way OpenSCAD source merge.\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
       "tier": "pro",
       "access": "pro",
       "category": "design_versioning",
@@ -9284,7 +9284,7 @@
     },
     {
       "name": "get_provenance_history",
-      "description": "Return provenance-log entries for explainability (Claim 35).\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
+      "description": "Return provenance-log entries for explainability.\n\nEverything in Free, plus calibration that learns your printer, mid-print edits, and unlimited textures and decorations.\nRequires Kiln Pro.\nUpgrade: https://kiln3d.com/pricing",
       "tier": "pro",
       "access": "pro",
       "category": "engineering",

--- a/kiln/src/kiln/tiers_and_terms.py
+++ b/kiln/src/kiln/tiers_and_terms.py
@@ -127,7 +127,7 @@ SIGNIN_COMMAND = "kiln signin"
 #: paid-side denial payloads: the public SME-leak gate counts
 #: ``agent_guidance`` as a curated-data field marker, and ``server.py`` — the
 #: biggest consumer of this constant — already names every printer vendor, so
-#: the pair trips a moat check that has nothing to do with refusal copy.
+#: the pair trips a leak check that has nothing to do with refusal copy.
 #: Cheaper to pick another word than to weaken a security gate over wording.
 AGENT_SIGNIN_HINT = (
     "Run `kiln signin` for the user — it opens a browser and finishes on its "

--- a/scripts/audit_served_surface_leak.py
+++ b/scripts/audit_served_surface_leak.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Served-surface leak gate — what a stranger reads without opening the source.
+
+Every MCP client receives the tool descriptions, parameter docs, prompt and
+resource descriptions, and the server instructions verbatim; ``kiln --help``
+prints every command docstring; the bundled paid-tool manifest registers a
+discovery stub on every free install; and the ``_meta`` notes in the shipped
+knowledge files ride along in the wheel.  None of that is source code, so the
+comment-and-docstring gates never saw it — which is how tool descriptions
+shipped with internal patent docket numbers, private module paths, the
+research bibliography behind curated values, and the internal label for the
+paid data.
+
+This gate builds the FREE-install view of the server in-process (kiln-pro
+blocked, so the discovery stubs appear exactly as a free user gets them),
+walks the CLI, reads the paid-tool manifest and the data ``_meta`` strings,
+and fails on any served text that names how the paid depth is built rather
+than what a tier unlocks.
+
+    python scripts/audit_served_surface_leak.py            # exit 0 clean, 2 leak, 3 no registry
+    python scripts/audit_served_surface_leak.py --dump /tmp/served.txt
+
+Run with the project's virtualenv Python and ``PYTHONPATH=kiln/src`` so the
+registry judged is the checkout under test.  The kiln-pro repo carries the
+twin gate for the descriptions only a kiln-pro install serves
+(``scripts/audit_served_docstrings.py``); keep the rule tables aligned.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _ROOT / "scripts"
+_SRC = _ROOT / "kiln" / "src"
+_PKG = _SRC / "kiln"
+_DATA = _PKG / "data"
+_MANIFEST = _PKG / "pro_tool_manifest.json"
+
+sys.path.insert(0, str(_SCRIPTS))
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# ── The rules ──────────────────────────────────────────────────────────────
+# Each pattern names HOW the paid depth is built (a leak), never WHAT a tier
+# unlocks (fine).  Tier names, outcomes, and the pricing URL never trip these.
+RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    # Branding the curated data in text a client reads.
+    ("moat self-label", re.compile(r"\bmoat\b", re.IGNORECASE)),
+    # A private module / file path or overlay filename.
+    ("private module or file path",
+     re.compile(r"\bkiln_pro[./][\w./-]+|\b\w+_pro_overlay\.json\b")),
+    # Internal patent docket numbers, claim/priority shorthand, bug tags.
+    # "patent pending" is a public statement and stays allowed.
+    ("internal docket or claim shorthand",
+     re.compile(r"\bKILN-\d{3}\b|\bpatent\b(?!\s+pending)|\bclaims?\s+\d+\b|"
+                r"\bpriorit(?:y|ies)\s+\d+\b|\bbug-X\d\b|crown[- ]jewel",
+                re.IGNORECASE)),
+    # Naming the withheld paid fields is a field inventory, not an outcome.
+    ("paid field inventory",
+     re.compile(r"\b(?:agent_notes|agent_guidance|failure_modes|general_rules|"
+                r"common_issues|use_case_ratings|break_in_tips|"
+                r"cycle_life_estimates|co_print)\b")),
+    # The sourcing playbook behind curated values.  Public standards (ISO,
+    # ASTM) are textbook and do not trip; named references and dated
+    # datasheet citations do.
+    ("research bibliography",
+     re.compile(r"cnc kitchen|matweb|ces edupack|\bspringer\b|shigley|"
+                r"datasheet[- ](?:grounded|derived)|vendor datasheets?|"
+                r"tds-derived|data ?sheets?\s*\(20\d\d", re.IGNORECASE)),
+    # Infrastructure vendor and storage internals.  Case-sensitive on
+    # purpose: an operator env-var name like KILN_CLOUD_SUPABASE_SECRET is the
+    # config interface and may be named; prose about the vendor may not.
+    ("infrastructure internals",
+     re.compile(r"(?<![A-Z_])Supabase\b|\bRLS\b|service[- ]role\s+key")),
+)
+
+# Consciously reviewed served texts that trip a rule for a non-leak reason.
+# Keyed by (surface id, rule name).  Add a row only with a reason comment.
+_ALLOWLIST: frozenset[tuple[str, str]] = frozenset()
+
+
+def _persona_rules():
+    """The public-language gate's persona / process-shorthand rules."""
+    try:
+        from check_public_language import find_violations
+    except Exception:  # noqa: BLE001 — the gate still runs without it
+        return None
+    return find_violations
+
+
+def judge(surface: str, text: str, find_violations=None) -> list[tuple[str, str, str]]:
+    """Return ``(rule, surface, excerpt)`` for every leak in *text*."""
+    hits: list[tuple[str, str, str]] = []
+    if not text:
+        return hits
+    for rule, pattern in RULES:
+        if (surface, rule) in _ALLOWLIST:
+            continue
+        for m in pattern.finditer(text):
+            start = max(0, m.start() - 50)
+            excerpt = " ".join(text[start:m.end() + 50].split())
+            hits.append((rule, surface, excerpt))
+    if find_violations is not None:
+        for f in find_violations(text, source=surface):
+            hits.append((f"persona/process: {f.rule}", surface, f.text[:120]))
+    return hits
+
+
+# ── Surfaces ───────────────────────────────────────────────────────────────
+
+def registry_texts() -> list[tuple[str, str]]:
+    """Every description the free-install MCP server hands to a client."""
+    import dump_tool_descriptions as dump
+
+    dump._block_pro_import()
+    data = dump.collect()
+    out: list[tuple[str, str]] = [("server:instructions", data["instructions"])]
+    for t in data["tools"]:
+        out.append((f"tool:{t['name']}", t["description"]))
+        for p in t["parameters"]:
+            if p["description"]:
+                out.append((f"tool:{t['name']}.{p['name']}", p["description"]))
+    for p in data["prompts"]:
+        out.append((f"prompt:{p['name']}", p["description"]))
+        for a in p["arguments"]:
+            out.append((f"prompt:{p['name']}.{a['name']}", a["description"]))
+    for r in data["resources"]:
+        out.append((f"resource:{r['uri']}", r["description"]))
+    return out
+
+
+def cli_texts() -> list[tuple[str, str]]:
+    """``--help`` for every command reachable from ``kiln``."""
+    import click
+
+    from kiln.cli.main import cli
+
+    out: list[tuple[str, str]] = []
+
+    def walk(cmd, path):
+        ctx = click.Context(cmd, info_name=path[-1])
+        try:
+            out.append(("cli:" + " ".join(path), cmd.get_help(ctx)))
+        except Exception as exc:  # noqa: BLE001 — a broken help is its own bug
+            out.append(("cli:" + " ".join(path), f"<help failed: {exc}>"))
+        if isinstance(cmd, click.Group):
+            for name in sorted(cmd.list_commands(ctx)):
+                sub = cmd.get_command(ctx, name)
+                if sub is not None:
+                    walk(sub, path + [name])
+
+    walk(cli, ["kiln"])
+    return out
+
+
+def _strings(node, path: str):
+    if isinstance(node, str):
+        yield path, node
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            yield from _strings(v, f"{path}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _strings(v, f"{path}[{i}]")
+
+
+def manifest_texts() -> list[tuple[str, str]]:
+    """Descriptions, parameter docs, nudges, and tier copy in the bundled manifest."""
+    if not _MANIFEST.is_file():
+        return []
+    m = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+    out: list[tuple[str, str]] = []
+    for path, s in _strings(m.get("tiers", {}), "manifest:tiers"):
+        out.append((path, s))
+    for t in m.get("tools", []):
+        name = t.get("name", "?")
+        out.append((f"manifest:{name}", t.get("description", "") or ""))
+        for pname, pdef in (t.get("parameters") or {}).get("properties", {}).items():
+            if isinstance(pdef, dict) and pdef.get("description"):
+                out.append((f"manifest:{name}.{pname}", pdef["description"]))
+        for path, s in _strings(t.get("upgrade_nudge") or {}, f"manifest:{name}.upgrade_nudge"):
+            out.append((path, s))
+    return out
+
+
+def data_meta_texts() -> list[tuple[str, str]]:
+    """Every string under an underscore key in the shipped knowledge files."""
+    out: list[tuple[str, str]] = []
+    for f in sorted(_DATA.rglob("*.json")):
+        if "scad_libraries" in f.parts:
+            continue
+        try:
+            doc = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        rel = f.relative_to(_PKG).as_posix()
+
+        def walk(node, path, under_meta):
+            if isinstance(node, dict):
+                for k, v in node.items():
+                    walk(v, f"{path}.{k}", under_meta or str(k).startswith("_"))
+            elif isinstance(node, list):
+                for i, v in enumerate(node):
+                    walk(v, f"{path}[{i}]", under_meta)
+            elif isinstance(node, str) and under_meta:
+                out.append((f"data:{rel}{path}", node))
+
+        walk(doc, "", False)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--dump", type=Path, help="write every judged text here")
+    parser.add_argument(
+        "--static-only", action="store_true",
+        help="judge only the manifest and data notes (no server import)",
+    )
+    args = parser.parse_args(argv)
+
+    surfaces: list[tuple[str, str]] = []
+    surfaces += manifest_texts()
+    surfaces += data_meta_texts()
+    if not args.static_only:
+        try:
+            surfaces += registry_texts()
+            surfaces += cli_texts()
+        except Exception as exc:  # noqa: BLE001 — report, never pass vacuously
+            print(f"served-surface leak gate: could not load the registry/CLI: {exc}")
+            return 3
+
+    if args.dump:
+        args.dump.write_text(
+            "\n".join(f"=== {s}\n{t}\n" for s, t in surfaces), encoding="utf-8"
+        )
+
+    fv = _persona_rules()
+    hits: list[tuple[str, str, str]] = []
+    for surface, text in surfaces:
+        hits.extend(judge(surface, text, fv))
+
+    counts = {}
+    for s, _ in surfaces:
+        counts[s.split(":")[0]] = counts.get(s.split(":")[0], 0) + 1
+    summary = ", ".join(f"{k} {v}" for k, v in sorted(counts.items()))
+    if hits:
+        print(f"served-surface leak gate: {len(hits)} leak(s) across {summary}\n")
+        for rule, surface, excerpt in hits:
+            print(f"  [{rule}] {surface}\n      …{excerpt}…")
+        print(
+            "\nFix the wording at the source (docstring, help text, manifest "
+            "generator, or data note): say what the tier unlocks, not how it is "
+            "built.  Allowlist a row only for a reviewed non-leak."
+        )
+        return 2
+    print(f"served-surface leak gate: clean ({summary} texts judged)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dump_tool_descriptions.py
+++ b/scripts/dump_tool_descriptions.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Dump every MCP tool, prompt, and resource description the server hands to clients.
+
+Everything an MCP client receives from ``tools/list`` — the tool name, its
+description (the docstring), and every parameter's description — is as
+public as the README: the hosted connector, the desktop app, and any
+``pip install kiln3d`` user can read it verbatim.  This script writes the
+whole surface to one file so it can be swept for wording that should not
+be there (internal module paths, private data-file names, thresholds and
+formulas, research provenance) without starting a client.
+
+    # what a free user sees: public tools + discovery stubs for paid tools
+    python scripts/dump_tool_descriptions.py --without-pro -o /tmp/tools_free.txt
+
+    # what a kiln-pro install / the hosted connector serves
+    python scripts/dump_tool_descriptions.py -o /tmp/tools_full.txt
+
+    # machine-readable copy for other gates
+    python scripts/dump_tool_descriptions.py --json /tmp/tools.json
+
+Run with the project's virtualenv Python and ``PYTHONPATH=kiln/src`` so the
+registry you dump is the checkout you are auditing, not an installed copy.
+Exit 0 always; this is a dump, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _block_pro_import() -> None:
+    """Make ``import kiln_pro`` raise ImportError for the rest of the process.
+
+    Setting a module's ``sys.modules`` entry to ``None`` is the documented
+    way to force ImportError, which is exactly the branch a free install
+    takes: the server then registers discovery stubs from the bundled
+    manifest instead of the real paid tools.
+    """
+    sys.modules["kiln_pro"] = None  # type: ignore[assignment]
+
+
+def _tool_schema(tool) -> dict:
+    params = getattr(tool, "parameters", None)
+    if isinstance(params, dict):
+        return params
+    meta = getattr(tool, "fn_metadata", None)
+    model = getattr(meta, "arg_model", None)
+    if model is not None and hasattr(model, "model_json_schema"):
+        try:
+            return model.model_json_schema()
+        except Exception:  # noqa: BLE001 — a schema that will not render is still a tool
+            return {}
+    return {}
+
+
+def collect() -> dict:
+    import kiln
+    from kiln.server import mcp
+
+    # Plugins (public and, when importable, kiln-pro) register at import
+    # time; a second call is a no-op but guards the mid-load retry path.
+    try:
+        from kiln.server import _ensure_internal_tool_plugins_registered
+
+        _ensure_internal_tool_plugins_registered()
+    except Exception:  # noqa: BLE001 — registry is whatever import produced
+        pass
+
+    tools = []
+    for tool in sorted(mcp._tool_manager.list_tools(), key=lambda t: t.name):
+        schema = _tool_schema(tool)
+        props = schema.get("properties", {}) if isinstance(schema, dict) else {}
+        required = set(schema.get("required", []) if isinstance(schema, dict) else [])
+        params = []
+        for pname, pdef in props.items():
+            if not isinstance(pdef, dict):
+                pdef = {}
+            ptype = pdef.get("type")
+            if ptype is None and "anyOf" in pdef:
+                ptype = "|".join(
+                    str(a.get("type", "?")) for a in pdef["anyOf"] if isinstance(a, dict)
+                )
+            params.append(
+                {
+                    "name": pname,
+                    "type": ptype,
+                    "required": pname in required,
+                    "default": pdef.get("default"),
+                    "description": pdef.get("description") or "",
+                }
+            )
+        fn = getattr(tool, "fn", None)
+        tools.append(
+            {
+                "name": tool.name,
+                "module": getattr(fn, "__module__", "") or "",
+                "description": tool.description or "",
+                "parameters": params,
+            }
+        )
+
+    prompts = []
+    try:
+        for p in sorted(mcp._prompt_manager.list_prompts(), key=lambda p: p.name):
+            prompts.append(
+                {
+                    "name": p.name,
+                    "description": p.description or "",
+                    "arguments": [
+                        {"name": a.name, "description": a.description or ""}
+                        for a in (p.arguments or [])
+                    ],
+                }
+            )
+    except Exception:  # noqa: BLE001 — prompts are optional
+        pass
+
+    resources = []
+    try:
+        for r in sorted(mcp._resource_manager.list_resources(), key=lambda r: str(r.uri)):
+            resources.append(
+                {"uri": str(r.uri), "name": r.name, "description": r.description or ""}
+            )
+        for t in sorted(mcp._resource_manager.list_templates(), key=lambda t: t.uri_template):
+            resources.append(
+                {
+                    "uri": t.uri_template,
+                    "name": t.name,
+                    "description": t.description or "",
+                }
+            )
+    except Exception:  # noqa: BLE001 — resources are optional
+        pass
+
+    return {
+        "kiln_source": str(Path(kiln.__file__).resolve().parent),
+        "kiln_pro_importable": sys.modules.get("kiln_pro") is not None
+        and "kiln_pro" in sys.modules,
+        "instructions": getattr(mcp, "instructions", None) or "",
+        "tool_count": len(tools),
+        "tools": tools,
+        "prompts": prompts,
+        "resources": resources,
+    }
+
+
+def render(data: dict) -> str:
+    out: list[str] = []
+    out.append(f"# kiln source: {data['kiln_source']}")
+    out.append(f"# kiln_pro importable: {data['kiln_pro_importable']}")
+    out.append(f"# tools: {data['tool_count']}  prompts: {len(data['prompts'])}  resources: {len(data['resources'])}")
+    out.append("")
+    out.append("=" * 78)
+    out.append("SERVER INSTRUCTIONS (static handshake text)")
+    out.append("=" * 78)
+    out.append(data["instructions"])
+    out.append("")
+    for t in data["tools"]:
+        out.append("=" * 78)
+        out.append(f"TOOL {t['name']}    [{t['module']}]")
+        out.append("=" * 78)
+        out.append(t["description"].rstrip())
+        if t["parameters"]:
+            out.append("")
+            out.append("PARAMETERS:")
+            for p in t["parameters"]:
+                req = "required" if p["required"] else f"default={p['default']!r}"
+                line = f"  - {p['name']} ({p['type']}, {req})"
+                if p["description"]:
+                    line += f": {p['description']}"
+                out.append(line)
+        out.append("")
+    for p in data["prompts"]:
+        out.append("=" * 78)
+        out.append(f"PROMPT {p['name']}")
+        out.append("=" * 78)
+        out.append(p["description"].rstrip())
+        for a in p["arguments"]:
+            out.append(f"  - {a['name']}: {a['description']}")
+        out.append("")
+    for r in data["resources"]:
+        out.append("=" * 78)
+        out.append(f"RESOURCE {r['uri']}    ({r['name']})")
+        out.append("=" * 78)
+        out.append(r["description"].rstrip())
+        out.append("")
+    return "\n".join(out) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("-o", "--out", type=Path, help="write the text dump here (default: stdout)")
+    parser.add_argument("--json", type=Path, help="also write a JSON copy here")
+    parser.add_argument(
+        "--without-pro",
+        action="store_true",
+        help="block `import kiln_pro` so the dump shows what a free install serves",
+    )
+    args = parser.parse_args(argv)
+
+    if args.without_pro:
+        _block_pro_import()
+
+    data = collect()
+    text = render(data)
+    if args.out:
+        args.out.write_text(text, encoding="utf-8")
+        print(
+            f"wrote {args.out} — {data['tool_count']} tools, "
+            f"{len(data['prompts'])} prompts, {len(data['resources'])} resources "
+            f"(kiln_pro importable: {data['kiln_pro_importable']}; source {data['kiln_source']})"
+        )
+    else:
+        sys.stdout.write(text)
+    if args.json:
+        args.json.write_text(json.dumps(data, indent=1, default=str), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_supported_printers.py
+++ b/scripts/generate_supported_printers.py
@@ -112,7 +112,7 @@ def build_surface() -> tuple[dict, list[tuple[str, list[str]]]]:
         brand = derive_manufacturer(pid, name)
         # PUBLIC SURFACE — name + id only. NEVER add per-model engineering specs
         # (build volume, temps, materials, ...) here: this JSON ships to the
-        # crawlable /printers page, and the curated catalog detail is moat.
+        # crawlable /printers page, and the curated catalog detail stays in Kiln Pro.
         # Pinned by test_public_surface_exposes_only_name_not_specs.
         by_brand.setdefault(brand, []).append(
             {"id": pid, "name": name}


### PR DESCRIPTION
## What changed

A sweep of every public-facing surface a stranger can read without opening the source: MCP tool descriptions and parameter docs (what `tools/list` hands to any client, including the hosted connector), upgrade nudges and error strings, `kiln --help` for all 294 commands, tracked Markdown, the ClawHub skill and registry manifests, `scripts/` and workflows, shipped JSON metadata, and the PyPI long description.

Bar: a user should learn what a tier unlocks; a competitor should not learn how it is built. Tier names and outcomes stay. Field inventories, private module paths, internal docket numbers, research bibliographies, and the internal label for the curated data go.

Six commits, one per surface (plus a merge of main):

1. **Public source / CLI** — tool descriptions, CLI help, and code comments no longer carry internal patent docket numbers, private `kiln_pro.*` paths, or the storage vendor behind sign-in. The `kiln goals` error told free users to `pip install kiln-pro`, which cannot work; it now points at sign-in / pricing.
2. **Shipped data notes** — every `_split_note` in `kiln/src/kiln/data/` listed the paid fields being withheld (`agent_notes`, `failure_modes`, `common_issues`, `use_case_ratings`, …); one listed the reference bibliography behind the curated values. They now say the depth lives in Kiln Pro and stop. No data values changed.
3. **`scripts/dump_tool_descriptions.py`** — dumps every tool / prompt / resource description the server serves, with `--without-pro` to see exactly what a free install gets (public tools + discovery stubs). Un-ignored in `.gitignore` alongside the other gates so the leak-gate task can reuse it.
4. **`pro_tool_manifest.json`** — regenerated from the paired kiln-pro branch; the only diff is seven descriptions losing ticket / priority / table-name shorthand. No tool added, removed, or re-tiered.
5. **Review lap** — the template catalog's own `_meta.description` still listed the withheld fields (caught by the new gate below); two joined docstring lines re-wrapped.
6. **`scripts/audit_served_surface_leak.py` + CI step** — the recurrence guard. Builds the free-install registry in-process, walks every `kiln --help`, reads the bundled manifest and every underscore-key string in the data files, and fails on: the internal label, private `kiln_pro` paths / overlay filenames, patent docket / claim / priority / bug shorthand, paid field inventories, research bibliographies (named references, dated datasheet citations), infrastructure internals, plus the public-language gate's persona rules. **A/B:** exit 2 with 33 hits on today's `origin/main`; exit 0 on this branch. It is a hard step (no `continue-on-error`), placed after the test steps so it does not collide with the sibling gate branch's edits to the moat-gate step.

Nothing a free user gets was reduced. Safety messages (PPE, food-safety, skin-contact, PTFE clamp) are untouched and free at every tier.

## Pairs with

[codeofaxel/Kiln-pro#75](https://github.com/codeofaxel/Kiln-pro/pull/75) (94 kiln-pro tool docstrings + CLI help served to hosted users, plus the twin gate). **Merge this one first.** kiln-pro's CI compares its manifest against public `main`'s copy and its new gate judges public `main`'s CLI help, so #75 goes green only once this PR is on `main`. This PR has no dependency on kiln-pro.

## Verification

- `python -m compileall -q kiln/src/kiln` clean
- `scripts/audit_moat_comment_leak.py`, `scripts/audit_public_sme_leak.py`, `scripts/check_public_language.py --range origin/main..HEAD` all clean
- Targeted tests for touched modules: 707 passed, 3 skipped; manifest readers: 79 passed
- Free-install tool dump re-swept after the change: 0 hits for private paths, docket refs, or the internal label
- New served-surface gate: clean on this branch after merging today's `main` (152 CLI texts, 161 data notes, 969 manifest texts, 886 tools)
- kiln-pro `scripts/check_manifest.py` judged against this checkout: in sync (417 tools)

Reported, not edited: shipped CHANGELOG entries that name the "overlay" architecture, the 0.4 mm nozzle baseline, and an "Internal" CI-guard note (frozen history). Full findings file lives outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
