### PR TITLE
Data notes lead with engineering depth; repair the load-table derivation

### DIFF
--- a/kiln/scripts/generate_load_tables.py
+++ b/kiln/scripts/generate_load_tables.py
@@ -184,8 +184,9 @@ def build() -> dict:
             ),
             "_split_note": (
                 "Safety-floor profile for AI-controlled FDM printing.  "
-                "Engineering depth (per-material SME caveats) is available "
-                "in Kiln Pro; see https://kiln3d.com/pricing."
+                "Engineering depth (the per-material caveats behind these "
+                "numbers) is available in Kiln Pro; see "
+                "https://kiln3d.com/pricing."
             ),
         },
     }

--- a/kiln/src/kiln/data/design_knowledge/design_templates.json
+++ b/kiln/src/kiln/data/design_knowledge/design_templates.json
@@ -2,7 +2,7 @@
   "_meta": {
     "version": "2.0.0",
     "domain": "fdm",
-    "description": "Discovery catalog of functional design templates for FDM printing. Each entry is identifiable by display_name, use_cases, and material compatibility — enough for an agent to surface the right template to the user. Engineering-grade depth for each template is available in Kiln Pro.",
+    "description": "Discovery catalog of functional design templates for FDM printing. Each entry is identifiable by display_name, use_cases, and material compatibility — enough for an agent to surface the right template to the user. Engineering depth for each template is available in Kiln Pro.",
     "_data_quality": {
       "last_audit_date": "2026-05-05",
       "primary_sources": [
@@ -12,7 +12,7 @@
        ],
       "methodology": "Conservative safety-floor values appropriate for AI-controlled FDM printing without expert supervision. Deeper curated engineering values ship in Kiln Pro."
     },
-    "_split_note": "Discovery + safety-floor profiles for AI-controlled FDM printing. Curated engineering depth for every template is available in Kiln Pro. See https://kiln3d.com/pricing."
+    "_split_note": "Discovery + safety-floor profiles for AI-controlled FDM printing. Engineering depth for every template (how to size it, what goes wrong, and why) is available in Kiln Pro. See https://kiln3d.com/pricing."
   },
   "snap_fit_cantilever": {
     "display_name": "Cantilever Snap Fit",

--- a/kiln/src/kiln/data/design_knowledge/environment_compatibility.json
+++ b/kiln/src/kiln/data/design_knowledge/environment_compatibility.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Material survival matrix for environment and exposure checks. Ratings are qualitative and intended for fast agent triage before geometry generation.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Deeper per-material guidance is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (what each rating means in practice and how long a part lasts) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "uv_resistance": {

--- a/kiln/src/kiln/data/design_knowledge/functional_requirements.json
+++ b/kiln/src/kiln/data/design_knowledge/functional_requirements.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Maps functional requirements to design constraints. When an agent describes what an object needs to DO, these rules translate into what the design needs to BE.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Worked design guidance is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (worked examples for each requirement) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "load_bearing": {
     "display_name": "Supports Weight / Load-Bearing",

--- a/kiln/src/kiln/data/design_knowledge/load_tables.json
+++ b/kiln/src/kiln/data/design_knowledge/load_tables.json
@@ -4,7 +4,7 @@
     "domain": "fdm",
     "description": "Per-material safe-load lookup for cantilevered FDM parts, DERIVED (not hand-authored): safe_load_N = tensile_capacity_n_per_mm2 x (A^1.5/6) / L, where tensile_capacity = catalogue tensile x 0.9 FDM print factor / 3.0 safety factor. SQUARE cross-section basis \u2014 wide or flat sections are weaker. Regenerate with kiln/scripts/generate_load_tables.py; never hand-edit values.",
     "_orientation_convention": "layer_orientation_derating keys: 'across_layers' = the load pulls the layer interfaces apart (build/Z direction \u2014 the WEAK case for FDM; factor 0.4, the worst per-material interlayer ratio so one conservative pair covers every material). 'along_layers' = the load acts within the layer planes (the STRONG case; factor 1.0). Per-material anisotropy depth lives in Kiln Pro.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-material engineering caveats are available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (the per-material caveats behind these numbers) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "tensile_capacity_n_per_mm2": 15.0,

--- a/kiln/src/kiln/data/design_knowledge/material_troubleshooting.json
+++ b/kiln/src/kiln/data/design_knowledge/material_troubleshooting.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Per-material troubleshooting: common print failures, root causes, and specific fixes. Agent-consumable for real-time print diagnostics.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-symptom diagnostic playbooks are available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (what is going wrong and how to fix it, symptom by symptom) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "storage_requirements": {

--- a/kiln/src/kiln/data/design_knowledge/materials.json
+++ b/kiln/src/kiln/data/design_knowledge/materials.json
@@ -13,7 +13,7 @@
       "update_cadence": "annual for established materials (PLA, PETG, ABS), semi-annual for newer composites (CF-Nylon, PA6-GF, PET-CF); high-performance polymers (PEI, PEEK, PEKK, PPSU, PPS) annual — their datasheets change rarely, but vendor process windows do",
       "methodology": "Conservative/worst-case values used for composites where manufacturer specs vary. Mechanical values represent typical FDM-printed properties (not injection-molded datasheets). Design limits empirically validated where possible."
     },
-    "_split_note": "Safety-floor profiles for AI-controlled FDM printing.  Engineering-grade material depth is available in Kiln Pro.  See https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profiles for AI-controlled FDM printing.  Engineering depth (how strong each material really is, what it is good for, and how to print it well) is available in Kiln Pro.  See https://kiln3d.com/pricing."
   },
   "pla": {
     "display_name": "PLA (Polylactic Acid)",

--- a/kiln/src/kiln/data/design_knowledge/multi_material_pairing.json
+++ b/kiln/src/kiln/data/design_knowledge/multi_material_pairing.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Dual-extrusion and multi-material compatibility rules. Which materials can be printed together, support dissolution methods, and interface adhesion.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-pair printing guidance is available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (how each pair behaves together and when to avoid one) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "support_pairs": [
     {

--- a/kiln/src/kiln/data/design_knowledge/post_processing.json
+++ b/kiln/src/kiln/data/design_knowledge/post_processing.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Post-processing techniques per material. Surface finishing, strengthening, and aesthetic treatments with specific procedures.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Step-by-step procedures and strengthening tradeoffs are available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (step-by-step finishing procedures and the tradeoffs of each) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "pla": {
     "techniques": [

--- a/kiln/src/kiln/data/design_knowledge/printer_material_compatibility.json
+++ b/kiln/src/kiln/data/design_knowledge/printer_material_compatibility.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Printer-to-material compatibility matrix. Maps which materials each printer can handle out-of-box, with upgrades, or not at all.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-printer, per-material notes are available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (what to expect from each printer and material together) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "anker_m5": {
     "pla": {

--- a/kiln/src/kiln/data/design_knowledge/printer_profiles.json
+++ b/kiln/src/kiln/data/design_knowledge/printer_profiles.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "domain": "fdm",
     "description": "Desktop printer capability profiles for material feasibility and design-for-manufacturing decisions.",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-printer positioning guidance is available in Kiln Pro; see https://kiln3d.com/pricing.",
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (how each printer actually behaves and what to design for) is available in Kiln Pro; see https://kiln3d.com/pricing.",
     "_default_profile_note": "The 'default' entry is the deliberately conservative stand-in for a printer Kiln has no profile for. Its numbers are the floor a commodity FDM machine can be assumed to meet, NOT a measurement of any product, so a feasibility answer given against it is the answer for the least capable plausible machine. Register the real printer to get a real answer."
   },
   "default": {

--- a/kiln/src/kiln/data/printer_intelligence.json
+++ b/kiln/src/kiln/data/printer_intelligence.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Printer intelligence database: firmware quirks, material compatibility, calibration guidance, and known failure modes. Keyed by the same printer_id as safety_profiles.json.",
     "updated": "2025-02-11",
-    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Per-printer quirks, calibration recipes, and failure-mode playbooks are available in Kiln Pro; see https://kiln3d.com/pricing."
+    "_split_note": "Safety-floor profile for AI-controlled FDM printing.  Engineering depth (each printer's quirks, its calibration recipes, and the failures it is known for) is available in Kiln Pro; see https://kiln3d.com/pricing."
   },
   "default": {
     "display_name": "Generic FDM Printer",


### PR DESCRIPTION
> **This PR repairs a red `main`.** My [#150](https://github.com/codeofaxel/Kiln/pull/150) commit `fc9a98ee` hand-edited `load_tables.json`, which is generated and compared byte-for-byte against its generator. `main` has been failing `test_table_matches_its_generator_exactly` since. This branch moves the wording into the generator, so merging it turns `main` green. It is also the only open branch touching that file, so landing it without the generator change would re-break the same test.

## What changed

Follow-up to [#150](https://github.com/codeofaxel/Kiln/pull/150). That PR removed the paid field names from the eleven split notes in the shipped knowledge files, and the phrase "engineering depth" went out with them. It is the clearest thing a reader gets at a glance, and it was never the leak: the field list in the parentheses was.

Every note now leads with that phrase and glosses it in plain English instead of key names.

Before, after #150:

```
Safety-floor profile for AI-controlled FDM printing.  Per-symptom diagnostic
playbooks are available in Kiln Pro; see https://kiln3d.com/pricing.
```

After:

```
Safety-floor profile for AI-controlled FDM printing.  Engineering depth (what is
going wrong and how to fix it, symptom by symptom) is available in Kiln Pro; see
https://kiln3d.com/pricing.
```

All eleven notes now share that shape, where before each described the paid depth its own way. No field, module, or source is named, so the served-surface gate still passes. No data values changed.

Ten of the eleven files are hand-maintained. The eleventh, `load_tables.json`, is generated, so its wording lives in `kiln/scripts/generate_load_tables.py` and the JSON is regenerated from it. On this branch that regeneration is a no-op, because the wording already in the file is exactly what the generator now emits.

## Verification

- `scripts/audit_served_surface_leak.py` clean (152 CLI texts, 161 data notes, 969 manifest texts, 886 tools)
- `scripts/audit_moat_comment_leak.py` and `scripts/check_public_language.py` clean, including this branch's commit message
- `test_load_tables_derivation.py`: fails at `53d498d1` (current `main`), passes here
- Every test that reads the changed data files, 10 files: 451 passed, 24 skipped here; the same set on `main` is 450 passed with the one derivation failure, so `#150` broke exactly this and nothing else
- Data and design-intelligence tests: 349 passed
- Every knowledge file still parses as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
