### PR TITLE
Prove the served-surface gate can fail

### DIFF
--- a/kiln/tests/test_served_surface_leak.py
+++ b/kiln/tests/test_served_surface_leak.py
@@ -53,6 +53,7 @@ def _j(*parts: str) -> str:
 
 _LABEL = _j("mo", "at")
 _PRIV = _j("kiln", "_pro")
+_OVERLAY_FILE = _j("_pro", "_overlay.json")
 
 #: The exact wording shapes the 2026-09-02 sweep found on served surfaces.
 #: Each must stay caught; a rule that stops matching its row is a rule that
@@ -71,6 +72,57 @@ _LEAK_SHAPES: tuple[tuple[str, str], ...] = (
     ("infrastructure internals", "On the hosted server (Supabase backend + a JWT tenant)"),
     ("infrastructure internals", "the permission check the cloud RLS will run"),
 )
+
+#: Every ALTERNATIVE each rule is built from, with a probe that only that
+#: alternative catches.  A fixture per rule is not enough: a rule spelling out
+#: nine field names is satisfied by one of them, so deleting any of the other
+#: eight silently stops the gate seeing that field while the suite stays green.
+#: Deleting an alternative must fail its row here.
+_ALTERNATIVES: dict[str, tuple[str, ...]] = {
+    "private-tier self-label": (
+        f"these curated values are the engineering {_LABEL}",
+    ),
+    "private module or file path": (
+        f"see ``{_PRIV}/_rest/org_admin_authz.py``",
+        f"reads printability{_OVERLAY_FILE} at startup",
+    ),
+    "internal docket or claim shorthand": (
+        "tracked as KILN-021 in the ledger",
+        "the patent covers this technique",
+        "per claim 51 the overlap must hold",
+        "runs the Priority 8 conflict detection",
+        "returns has_conflicts (bug-X2 correct)",
+        "the crown-jewel surface",
+    ),
+    "paid field inventory": (
+        "the paid tier restores agent_notes for each material",
+        "the paid tier restores agent_guidance for each material",
+        "the paid tier restores failure_modes for each printer",
+        "the paid tier restores general_rules for co-printing",
+        "the paid tier restores common_issues for each symptom",
+        "the paid tier restores use_case_ratings for each material",
+        "the paid tier restores break_in_tips for each printer",
+        "the paid tier restores cycle_life_estimates for each block",
+        "the paid tier restores co_print notes for each pair",
+    ),
+    "research bibliography": (
+        "measured by CNC Kitchen on a worn nozzle",
+        "cross-checked against MatWeb",
+        "cross-checked against CES EduPack",
+        "per the Springer wear methodology",
+        "per Shigley for the shear fraction",
+        "datasheet-grounded values for each grade",
+        "datasheet-derived values for each grade",
+        "compiled from vendor datasheets",
+        "tds-derived numbers for each grade",
+        "filament data sheets (2024-2025)",
+    ),
+    "infrastructure internals": (
+        "hosted on Supabase behind a JWT",
+        "the permission check the cloud RLS will run",
+        "needs the service-role key to write",
+    ),
+}
 
 #: Wording that sells the upgrade or names the interface.  None of it may trip
 #: a rule: a gate that flags the funnel gets switched off by the next person
@@ -98,6 +150,33 @@ def test_each_leak_shape_is_still_caught(rule: str, text: str) -> None:
     assert rule in _rules_hit(text), (
         f"the {rule!r} rule no longer matches {text!r} — if its pattern was "
         "reworded, the gate now runs green without looking"
+    )
+
+
+@pytest.mark.parametrize(
+    "rule, probe",
+    [(rule, probe) for rule, probes in _ALTERNATIVES.items() for probe in probes],
+)
+def test_each_alternative_within_a_rule_is_still_caught(rule: str, probe: str) -> None:
+    """Fails when any single alternative is dropped from a rule.
+
+    The level below the per-rule fixtures: a rule is an alternation, and
+    deleting one branch of it blinds the gate to that shape alone, which no
+    per-rule fixture notices.
+    """
+    assert rule in _rules_hit(probe), (
+        f"the {rule!r} rule no longer matches {probe!r} — an alternative was "
+        "dropped from its pattern and the gate is now blind to that shape"
+    )
+
+
+def test_every_rule_declares_its_alternatives() -> None:
+    """A rule added later cannot arrive with only a coarse fixture."""
+    declared = {rule for rule, _ in _GATE.RULES}
+    pinned = set(_ALTERNATIVES)
+    assert declared == pinned, (
+        f"rules missing per-alternative probes: {sorted(declared - pinned)}; "
+        f"probes for rules that no longer exist: {sorted(pinned - declared)}"
     )
 
 

--- a/kiln/tests/test_served_surface_leak.py
+++ b/kiln/tests/test_served_surface_leak.py
@@ -1,0 +1,181 @@
+"""CI backstop for the served-surface leak gate.
+
+Everything an MCP client receives — tool and parameter descriptions, prompt
+and resource text, the server instructions, ``kiln --help``, the bundled
+paid-tool manifest, and the ``_meta`` notes in the shipped knowledge files —
+is as public as the README.  ``scripts/audit_served_surface_leak.py`` judges
+that text for wording which names HOW the paid depth is built rather than
+WHAT a tier unlocks.
+
+A green run proves we did not ship the method.  It proves nothing on its own,
+though: a gate whose pattern no longer matches anything also runs green, and
+says nothing about having stopped looking.  So the tests below plant a real
+self-label into a served surface and assert the gate FAILS on it, then remove
+it and assert clean — and pin each rule literal, because rewording one is the
+edit that turns this gate into a no-op.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _ROOT / "scripts" / "audit_served_surface_leak.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("audit_served_surface_leak", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_GATE = _load_gate()
+
+def _j(*parts: str) -> str:
+    """Join fixture fragments into one literal.
+
+    The shapes below are assembled from parts on purpose: the sibling
+    leak gates scan ``kiln/tests`` for these very literals, so spelling
+    them out whole would make this file trip them and need an exemption
+    everywhere.  Same reason ``check_public_language.py`` splits its
+    retired-provider token.
+    """
+    return "".join(parts)
+
+
+_LABEL = _j("mo", "at")
+_PRIV = _j("kiln", "_pro")
+
+#: The exact wording shapes the 2026-09-02 sweep found on served surfaces.
+#: Each must stay caught; a rule that stops matching its row is a rule that
+#: has been reworded into silence.  Every entry in ``RULES`` needs a row here
+#: (pinned by ``test_every_rule_has_a_fixture``), so a rule added later
+#: cannot ship unpinned the way the self-label rule did.
+_LEAK_SHAPES: tuple[tuple[str, str], ...] = (
+    ("private-tier self-label", f"these curated values are the engineering {_LABEL}"),
+    ("private module or file path", f"see ``{_PRIV}/_rest/org_admin_authz.py``"),
+    ("private module or file path", f"pipes through :mod:`{_PRIV}.recovery.mid_print_engine`"),
+    ("internal docket or claim shorthand", "Patent: KILN-021 Priority 8 (crown jewel)."),
+    ("internal docket or claim shorthand", "the improved prompt, per claim 51's overlap rule"),
+    ("paid field inventory", "Engineering depth (agent_notes + failure_modes) is Pro"),
+    ("research bibliography", "CNC Kitchen XT-CF20 destructive cross-section"),
+    ("research bibliography", "grounded in filament datasheets (2024-2025)"),
+    ("infrastructure internals", "On the hosted server (Supabase backend + a JWT tenant)"),
+    ("infrastructure internals", "the permission check the cloud RLS will run"),
+)
+
+#: Wording that sells the upgrade or names the interface.  None of it may trip
+#: a rule: a gate that flags the funnel gets switched off by the next person
+#: who has to ship.
+_ALLOWED_WORDING: tuple[str, ...] = (
+    "Requires Kiln Business. Pricing: https://kiln3d.com/pricing",
+    "Engineering depth (what is going wrong and how to fix it) is available in Kiln Pro.",
+    "Kiln Pro adds per-printer firmware quirks and failure-mode playbooks.",
+    "Decoration engine (patent pending).",
+    "Needs ``KILN_CLOUD_SUPABASE_SECRET`` or ``SUPABASE_SERVICE_ROLE_KEY``.",
+    "Grounded in ASTM D638 and ISO 527 tensile methodology.",
+    "Jobs are executed in priority order, with FIFO tie-breaking.",
+)
+
+
+def _rules_hit(text: str) -> set[str]:
+    return {rule for rule, _, _ in _GATE.judge("tool:example", text)}
+
+
+# ── The rule table still catches what it was built to catch ────────────────
+
+@pytest.mark.parametrize("rule, text", _LEAK_SHAPES)
+def test_each_leak_shape_is_still_caught(rule: str, text: str) -> None:
+    """Fails the moment a RULES literal is reworded into silence."""
+    assert rule in _rules_hit(text), (
+        f"the {rule!r} rule no longer matches {text!r} — if its pattern was "
+        "reworded, the gate now runs green without looking"
+    )
+
+
+def test_every_rule_has_a_fixture() -> None:
+    """Every rule in the table is exercised by a planted leak above.
+
+    This is the part that stops the gap recurring rather than closing this
+    one instance: a rule added later with no fixture fails here immediately,
+    instead of sitting undetectable the way the self-label rule did from the
+    day the gate landed.
+    """
+    declared = {rule for rule, _ in _GATE.RULES}
+    covered = {rule for rule, _ in _LEAK_SHAPES}
+    missing = sorted(declared - covered)
+    assert not missing, (
+        f"rules with no planted fixture: {missing}. Add a row to _LEAK_SHAPES "
+        "so the rule is proven to fire, not merely present."
+    )
+
+
+@pytest.mark.parametrize("text", _ALLOWED_WORDING)
+def test_funnel_and_interface_wording_is_not_flagged(text: str) -> None:
+    assert not _rules_hit(text)
+
+
+# ── The gate actually fails on a leak planted in a real served surface ─────
+
+def _plant(data_dir: Path, note: str) -> None:
+    (data_dir / "design_knowledge").mkdir(parents=True, exist_ok=True)
+    (data_dir / "design_knowledge" / "planted.json").write_text(
+        json.dumps({"_meta": {"description": note}}), encoding="utf-8"
+    )
+
+
+def test_planted_self_label_in_a_data_note_fails_the_gate(tmp_path, monkeypatch, capsys) -> None:
+    """A genuine self-label on a served surface must exit non-zero and be named."""
+    monkeypatch.setattr(_GATE, "_DATA", tmp_path)
+    monkeypatch.setattr(_GATE, "_PKG", tmp_path)
+    _plant(tmp_path, f"these curated values are the engineering {_LABEL}")
+
+    assert _GATE.main(["--static-only"]) == 2
+    out = capsys.readouterr().out
+    assert "planted.json" in out
+    assert "private-tier self-label" in out
+
+
+def test_gate_is_clean_once_the_plant_is_removed(tmp_path, monkeypatch) -> None:
+    """The same surface, benign wording: clean.  Pins that the failure above
+    came from the planted text and not from the fixture itself."""
+    monkeypatch.setattr(_GATE, "_DATA", tmp_path)
+    monkeypatch.setattr(_GATE, "_PKG", tmp_path)
+    _plant(tmp_path, "Engineering depth is available in Kiln Pro; see https://kiln3d.com/pricing.")
+
+    assert _GATE.main(["--static-only"]) == 0
+
+
+def test_planted_leak_is_caught_on_every_served_rule(tmp_path, monkeypatch) -> None:
+    """Every rule, planted through the real data-note reader, not just judge()."""
+    monkeypatch.setattr(_GATE, "_DATA", tmp_path)
+    monkeypatch.setattr(_GATE, "_PKG", tmp_path)
+    for rule, text in _LEAK_SHAPES:
+        _plant(tmp_path, text)
+        hits = {h[0] for s, t in _GATE.data_meta_texts() for h in _GATE.judge(s, t)}
+        assert rule in hits, f"{rule!r} not raised for a planted {text!r}"
+
+
+# ── The live tree stays green ──────────────────────────────────────────────
+
+def test_live_served_surface_is_clean() -> None:
+    """The real registry, CLI, manifest and data notes judge clean.
+
+    Meaningful only because the plant tests above prove the gate can fail.
+    """
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/scripts/audit_served_surface_leak.py
+++ b/scripts/audit_served_surface_leak.py
@@ -58,7 +58,7 @@ if str(_SRC) not in sys.path:
 # MORE, and prove the new shape fails before trusting it.
 RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     # Branding the curated data in text a client reads.
-    ("moat self-label", re.compile(r"\bmoat\b", re.IGNORECASE)),
+    ("private-tier self-label", re.compile(r"\bmoat\b", re.IGNORECASE)),
     # A private module / file path or overlay filename.
     ("private module or file path",
      re.compile(r"\bkiln_pro[./][\w./-]+|\b\w+_pro_overlay\.json\b")),

--- a/scripts/audit_served_surface_leak.py
+++ b/scripts/audit_served_surface_leak.py
@@ -48,6 +48,14 @@ if str(_SRC) not in sys.path:
 # ── The rules ──────────────────────────────────────────────────────────────
 # Each pattern names HOW the paid depth is built (a leak), never WHAT a tier
 # unlocks (fine).  Tier names, outcomes, and the pricing URL never trip these.
+#
+# DO NOT reword the literals below to avoid the words they catch.  Here the
+# word IS the rule, not prose about the rule: a cleanup pass that "tidies"
+# them turns the matching check into a no-op, and a blinded gate reports
+# clean forever without ever saying it stopped looking.  The sibling gate
+# exempts this file for exactly that reason (``_SELF`` in
+# ``audit_moat_comment_leak.py``).  Change a pattern only to make it catch
+# MORE, and prove the new shape fails before trusting it.
 RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     # Branding the curated data in text a client reads.
     ("moat self-label", re.compile(r"\bmoat\b", re.IGNORECASE)),


### PR DESCRIPTION
## What changed

The served-surface leak gate that [#150](https://github.com/codeofaxel/Kiln/pull/150) added was the only one of the four leak gates with no test. That is worse than it sounds, because it blocks in CI: a blocking gate that cannot detect is a green check that means nothing.

Three commits.

**A test that proves the gate can fail.** It plants each leak shape through the real data-note reader, asserts a non-zero exit that names the offending surface, plants benign wording and asserts clean, and requires every rule in the table to have a fixture. That last one is the part that stops this recurring rather than fixing one instance: a rule added later with no coverage fails immediately, instead of sitting undetectable the way the self-label rule has since #150 landed.

**A pin on every alternative, not just every rule.** A rule is an alternation, so a fixture per rule is satisfied by one branch of it. Deleting any of the other eight field names in the paid-inventory rule stopped the gate seeing that field entirely, while all 22 tests stayed green. Each alternative now carries a probe only it can catch, and a structural test requires every rule to declare its alternatives, so a rule cannot arrive with only a coarse fixture.

**A comment saying the literals are the rule.** The patterns hold the exact words they catch, so a cleanup pass that rewords them for tidiness does not weaken the gate, it deletes it. The comment warns the person who opens the file; the test catches the person who does not.

The self-label rule is renamed to `private-tier self-label` and the test fixtures are assembled from fragments, so this file carries none of the literals the sibling gates scan `kiln/tests` for and needs no exemption on anyone's branch. Verified against the gate on [#149](https://github.com/codeofaxel/Kiln/pull/149): clean, and it adds no new private path to that gate's frozen inventory.

## A/B

Blinding the self-label pattern with a nonsense token, on a tree carrying a genuine planted self-label:

Blinding the self-label pattern with a nonsense token, on a tree carrying a genuine planted self-label: 3 failed, 19 passed, the three that should notice.

Deleting a single alternative from inside a rule, which the first version of this test missed entirely:

```
# agent_notes removed from the paid-inventory rule
FAILED ...[paid field inventory-the paid tier restores agent_notes for each material]
1 failed, 53 passed

# RLS removed from the infrastructure rule
FAILED ...[infrastructure internals-the permission check the cloud RLS will run]
FAILED ...test_planted_leak_is_caught_on_every_served_rule
3 failed, 51 passed
```

Restored each time: 54 passed, with the gate file byte-identical to its committed state, checked with `git diff --quiet` rather than by eye.

## Credit

Both gaps were found by the other two sessions in this sweep, not by me. The session on [#151](https://github.com/codeofaxel/Kiln/pull/151) planted a self-label, watched a blinded copy report clean, and restored its tree before reporting. The session on [#149](https://github.com/codeofaxel/Kiln/pull/149) then found that my first fix was itself satisfied by one alternative per rule, which #151 reproduced independently. The meta-test, the split fixtures, and the per-alternative design are all theirs, adopted here and re-verified on this tree rather than taken on report.

## Verification

- 54 tests pass; the three gates and the commit-message check are clean
- The test file trips no sibling gate and adds nothing to #149's frozen path inventory, verified by running that gate against it
- The live gate still judges the same counts: 152 CLI texts, 161 data notes, 969 manifest texts, 886 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
